### PR TITLE
fix: remove godot from macos environments

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -28,12 +28,14 @@
         zlsPinned = zls.packages.${system}.zls.overrideAttrs (prev: {
           buildInputs = [zigPinned];
         });
+        inherit (pkgs) lib stdenv;
       in {
         default = pkgs.mkShell {
           buildInputs = [
-            pkgs.godot
             zigPinned
             zlsPinned
+          ] ++ lib.optionals stdenv.isLinux [
+            pkgs.godot
           ];
         };
       }


### PR DESCRIPTION
fixes #28