### PR TITLE
fix: docs not running due to module infinite recursion

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -29,7 +29,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build documentation
-        run: zig build docs -Dheaders=DEPENDENCY
+        run: zig build docs --release=fast -Dheaders=DEPENDENCY
 
       - name: Setup Pages
         uses: actions/configure-pages@v4

--- a/bindgen/codegen.zig
+++ b/bindgen/codegen.zig
@@ -2,7 +2,7 @@ pub fn generate(ctx: *Context) !void {
     try generateBuiltins(ctx);
     try generateClasses(ctx);
     try generateGlobalEnums(ctx);
-    try generateModules(ctx);
+    // try generateModules(ctx);
     try generateUtilityFunctions(ctx);
 
     try generateCore(ctx);
@@ -716,7 +716,7 @@ fn generateCore(ctx: *Context) !void {
 
     try w.writeLine(
         \\const std = @import("std");
-        \\const godot = @import("godot");
+        \\const godot = @import("../root.zig");
         \\pub const util = @import("util.zig");
         \\pub const c = @import("gdextension");
     );
@@ -830,24 +830,22 @@ fn generateCore(ctx: *Context) !void {
 
 fn generateImports(w: *Writer, imports: *const Imports) !void {
     try w.writeLine(
-        \\const godot = @import("godot");
-        \\const vector = @import("vector");
+        \\const godot = @import("../root.zig");
     );
 
     var iter = imports.iterator();
     while (iter.next()) |import| {
         if (util.isBuiltinType(import.*)) continue;
 
-        const path = if (std.mem.startsWith(u8, import.*, "Vector"))
-            "godot"
-        else if (std.mem.eql(u8, import.*, "Variant"))
-            "godot"
-        else if (std.mem.eql(u8, import.*, "global"))
-            "godot"
-        else
-            "godot.core";
-
-        try w.printLine("const {0s} = {1s}.{0s};", .{ import.*, path });
+        if (std.mem.startsWith(u8, import.*, "Vector")) {
+            try w.printLine("const {0s} = @import(\"vector\").{0s};", .{import.*});
+        } else if (std.mem.eql(u8, import.*, "Variant")) {
+            try w.writeLine("const Variant = @import(\"../Variant.zig\");");
+        } else if (std.mem.eql(u8, import.*, "global")) {
+            try w.writeLine("const global = @import(\"global.zig\");");
+        } else {
+            try w.printLine("const {0s} = @import(\"core.zig\").{0s};", .{import.*});
+        }
     }
 }
 

--- a/src/bindings
+++ b/src/bindings
@@ -1,0 +1,1 @@
+../zig-out/bindings

--- a/src/root.zig
+++ b/src/root.zig
@@ -1,8 +1,9 @@
 const std = @import("std");
 
-pub const core = @import("godot_core");
-pub const c = core.c;
-pub const global = core.global;
+pub const c = @import("gdextension");
+pub const core = @import("bindings/core.zig");
+pub const global = @import("bindings/core.zig").global;
+
 pub const support = @import("support.zig");
 pub const Variant = @import("Variant.zig");
 


### PR DESCRIPTION
this removes the "core" module and assembles a single module by first copying the files into a temporary directory before building them.

the added benefit is we now get LSP support for the bindings, if you run `zig build bindings` first, since we can just add symlink to zig-out in the src folder