### PR TITLE
perf: improve bindgen performance and add timing outputs

### DIFF
--- a/bindgen/codegen.zig
+++ b/bindgen/codegen.zig
@@ -25,7 +25,6 @@ fn writeBuiltins(ctx: *Context) !void {
         try writeBuiltin(&writer, builtin);
 
         try buf.flush();
-        try file.sync();
     }
 }
 
@@ -233,7 +232,6 @@ fn writeGlobalEnums(ctx: *Context) !void {
     }
 
     try buf.flush();
-    try file.sync();
 }
 
 fn writeEnum(w: *Writer, @"enum": *const Context.Enum) !void {
@@ -464,7 +462,6 @@ fn writeModules(ctx: *Context) !void {
         try writeModule(&writer, module);
 
         try buf.flush();
-        try file.sync();
     }
 }
 
@@ -591,7 +588,6 @@ fn generateClasses(ctx: *Context) !void {
         try generateClass(&writer, class, ctx);
 
         try buf.flush();
-        try file.sync();
     }
 }
 
@@ -1048,7 +1044,6 @@ fn generateCore(ctx: *Context) !void {
     }
 
     try buf.flush();
-    try file.sync();
 }
 
 pub const ProcType = enum {

--- a/build.zig
+++ b/build.zig
@@ -214,7 +214,7 @@ fn buildBindgen(
 } {
     const mod = b.addModule("bindgen", .{
         .target = opt.target,
-        .optimize = opt.optimize,
+        .optimize = .ReleaseFast,
         .root_source_file = b.path("bindgen/main.zig"),
         .link_libc = true,
     });


### PR DESCRIPTION
before

```
Parser time: 267.05ms
Context time: 585.64ms
Codegen time: 4698.74ms
Format time: 10.01ms
Total time: 5561.44ms
```

after

```
Parser time: 34.15ms
Context time: 63.38ms
Codegen time: 324.83ms
Format time: 8.48ms
Total time: 430.84ms
```