### PR TITLE
refactor(docs): refactor docs module to use DocumentContext

### DIFF
--- a/bindgen/Config.zig
+++ b/bindgen/Config.zig
@@ -69,4 +69,3 @@ pub fn deinit(self: *Config) void {
 
 const std = @import("std");
 const fs = std.fs;
-const Allocator = std.mem.Allocator;

--- a/bindgen/Context.zig
+++ b/bindgen/Context.zig
@@ -418,7 +418,7 @@ fn castEnums(self: *Context, allocator: Allocator) !void {
         if (@"enum".is_bitfield) {
             continue;
         }
-        try self.enums.put(allocator, @"enum".name, try .fromGlobalEnum(allocator, @"enum", self));
+        try self.enums.put(allocator, @"enum".name, try .fromGlobalEnum(allocator, null, @"enum", self));
     }
 }
 

--- a/bindgen/Context.zig
+++ b/bindgen/Context.zig
@@ -427,7 +427,7 @@ fn castFlags(self: *Context, allocator: Allocator) !void {
         if (!@"enum".is_bitfield) {
             continue;
         }
-        try self.flags.put(allocator, @"enum".name, try .fromGlobalEnum(allocator, @"enum", self));
+        try self.flags.put(allocator, @"enum".name, try .fromGlobalEnum(allocator, null, @"enum", self));
     }
 }
 

--- a/bindgen/Context/Builtin.zig
+++ b/bindgen/Context/Builtin.zig
@@ -29,7 +29,7 @@ pub fn fromApi(allocator: Allocator, api: GodotApi.Builtin, ctx: *const Context)
     };
     self.api_name = api.name;
     self.size = size_config.size;
-    self.doc = if (api.description) |desc| try docs.convertDocsToMarkdown(allocator, desc, ctx) else null;
+    self.doc = if (api.description) |desc| try docs.convertDocsToMarkdown(allocator, desc, ctx, .{}) else null;
     self.has_destructor = api.has_destructor;
 
     for (api.constants orelse &.{}) |constant| {

--- a/bindgen/Context/Builtin.zig
+++ b/bindgen/Context/Builtin.zig
@@ -69,7 +69,7 @@ pub fn fromApi(allocator: Allocator, api: GodotApi.Builtin, ctx: *const Context)
     }
 
     for (api.methods orelse &.{}) |method| {
-        try self.methods.put(allocator, method.name, try Function.fromBuiltinMethod(allocator, method, ctx));
+        try self.methods.put(allocator, method.name, try Function.fromBuiltinMethod(allocator, self.name, method, ctx));
     }
 
     return self;

--- a/bindgen/Context/Class.zig
+++ b/bindgen/Context/Class.zig
@@ -78,13 +78,13 @@ pub fn fromApi(allocator: Allocator, api: GodotApi.Class, ctx: *const Context) !
         if (@"enum".is_bitfield) {
             try self.flags.put(allocator, @"enum".name, try Flag.fromGlobalEnum(allocator, @"enum", ctx));
         } else {
-            try self.enums.put(allocator, @"enum".name, try Enum.fromClass(allocator, @"enum"));
+            try self.enums.put(allocator, @"enum".name, try Enum.fromClass(allocator, self.name_api, @"enum", ctx));
         }
     }
 
     // Methods
     for (api.methods orelse &.{}) |method| {
-        try self.functions.put(allocator, method.name, try Function.fromClass(allocator, method, ctx));
+        try self.functions.put(allocator, method.name, try Function.fromClass(allocator, self.name_api, method, ctx));
     }
 
     // Properties

--- a/bindgen/Context/Class.zig
+++ b/bindgen/Context/Class.zig
@@ -42,9 +42,9 @@ pub fn fromApi(allocator: Allocator, api: GodotApi.Class, ctx: *const Context) !
 
     // Documentation
     self.doc = if (api.description) |desc|
-        try docs.convertDocsToMarkdown(allocator, desc, ctx)
+        try docs.convertDocsToMarkdown(allocator, desc, ctx, .{})
     else if (api.brief_description) |desc|
-        try docs.convertDocsToMarkdown(allocator, desc, ctx)
+        try docs.convertDocsToMarkdown(allocator, desc, ctx, .{})
     else
         null;
 
@@ -146,15 +146,12 @@ pub fn getBase(self: *const Class, ctx: *const Context) ?*Class {
 
 const std = @import("std");
 const Allocator = std.mem.Allocator;
-const ArrayList = std.ArrayListUnmanaged;
 const StringArrayHashMap = std.StringArrayHashMapUnmanaged;
-const StringHashMap = std.StringHashMapUnmanaged;
 
 const Context = @import("../Context.zig");
 const Constant = Context.Constant;
 const Enum = Context.Enum;
 const Flag = Context.Flag;
-const Field = Context.Field;
 const Function = Context.Function;
 const Imports = Context.Imports;
 const Property = Context.Property;

--- a/bindgen/Context/Class.zig
+++ b/bindgen/Context/Class.zig
@@ -42,9 +42,13 @@ pub fn fromApi(allocator: Allocator, api: GodotApi.Class, ctx: *const Context) !
 
     // Documentation
     self.doc = if (api.description) |desc|
-        try docs.convertDocsToMarkdown(allocator, desc, ctx, .{})
+        try docs.convertDocsToMarkdown(allocator, desc, ctx, .{
+            .current_class = api.name,
+        })
     else if (api.brief_description) |desc|
-        try docs.convertDocsToMarkdown(allocator, desc, ctx, .{})
+        try docs.convertDocsToMarkdown(allocator, desc, ctx, .{
+            .current_class = api.name,
+        })
     else
         null;
 
@@ -76,7 +80,7 @@ pub fn fromApi(allocator: Allocator, api: GodotApi.Class, ctx: *const Context) !
     // Enums
     for (api.enums orelse &.{}) |@"enum"| {
         if (@"enum".is_bitfield) {
-            try self.flags.put(allocator, @"enum".name, try Flag.fromGlobalEnum(allocator, @"enum", ctx));
+            try self.flags.put(allocator, @"enum".name, try Flag.fromGlobalEnum(allocator, self.name_api, @"enum", ctx));
         } else {
             try self.enums.put(allocator, @"enum".name, try Enum.fromClass(allocator, self.name_api, @"enum", ctx));
         }

--- a/bindgen/Context/Constant.zig
+++ b/bindgen/Context/Constant.zig
@@ -42,6 +42,5 @@ const std = @import("std");
 const Allocator = std.mem.Allocator;
 
 const Context = @import("../Context.zig");
-const Imports = Context.Imports;
 const Type = Context.Type;
 const GodotApi = @import("../GodotApi.zig");

--- a/bindgen/Context/Enum.zig
+++ b/bindgen/Context/Enum.zig
@@ -34,7 +34,7 @@ pub fn fromGlobalEnum(allocator: Allocator, api: GodotApi.GlobalEnum, ctx: *cons
 
     self.name = try allocator.dupe(u8, api.name);
     for (api.values) |value| {
-        const desc = if (value.description) |d| try docs.convertDocsToMarkdown(allocator, d, ctx) else null;
+        const desc = if (value.description) |d| try docs.convertDocsToMarkdown(allocator, d, ctx, .{}) else null;
         try self.values.put(allocator, value.name, try .init(allocator, desc, value.name, value.value));
     }
 

--- a/bindgen/Context/Field.zig
+++ b/bindgen/Context/Field.zig
@@ -9,7 +9,7 @@ pub fn init(allocator: Allocator, doc: ?[]const u8, name: []const u8, @"type": [
     var self: Field = .{};
     errdefer self.deinit(allocator);
 
-    self.doc = if (doc) |d| try docs.convertDocsToMarkdown(allocator, d, ctx) else null;
+    self.doc = if (doc) |d| try docs.convertDocsToMarkdown(allocator, d, ctx, .{}) else null;
     self.name = try allocator.dupe(u8, name);
     self.type = try Type.from(allocator, meta orelse @"type", meta != null, ctx);
     self.offset = offset;

--- a/bindgen/Context/Flag.zig
+++ b/bindgen/Context/Flag.zig
@@ -82,7 +82,7 @@ pub const Field = struct {
     default: bool = false,
 
     pub fn fromGlobalEnum(allocator: Allocator, api: GodotApi.GlobalEnum.Value, ctx: *const Context, default: i64) !Field {
-        const doc = if (api.description) |desc| try docs.convertDocsToMarkdown(allocator, desc, ctx) else null;
+        const doc = if (api.description) |desc| try docs.convertDocsToMarkdown(allocator, desc, ctx, .{}) else null;
         errdefer allocator.free(doc orelse "");
 
         const name = try case.allocTo(allocator, .snake, api.name);
@@ -109,7 +109,7 @@ pub const Const = struct {
     value: i64 = 0,
 
     pub fn fromGlobalEnum(allocator: Allocator, api: GodotApi.GlobalEnum.Value, ctx: *const Context) !Const {
-        const doc = if (api.description) |desc| try docs.convertDocsToMarkdown(allocator, desc, ctx) else null;
+        const doc = if (api.description) |desc| try docs.convertDocsToMarkdown(allocator, desc, ctx, .{}) else null;
         errdefer allocator.free(doc orelse "");
 
         const name = try case.allocTo(allocator, .snake, api.name);

--- a/bindgen/Context/Function.zig
+++ b/bindgen/Context/Function.zig
@@ -20,7 +20,9 @@ pub fn fromBuiltinConstructor(allocator: Allocator, builtin_name: []const u8, co
     var self = Function{};
     errdefer self.deinit(allocator);
 
-    self.doc = if (constructor.description) |doc| try docs.convertDocsToMarkdown(allocator, doc, ctx, .{}) else null;
+    self.doc = if (constructor.description) |doc| try docs.convertDocsToMarkdown(allocator, doc, ctx, .{
+        .current_class = builtin_name,
+    }) else null;
     self.name = blk: {
         var buf: ArrayList(u8) = .empty;
         errdefer buf.deinit(allocator);
@@ -61,11 +63,13 @@ pub fn fromBuiltinConstructor(allocator: Allocator, builtin_name: []const u8, co
     return self;
 }
 
-pub fn fromBuiltinMethod(allocator: Allocator, method: GodotApi.Builtin.Method, ctx: *const Context) !Function {
+pub fn fromBuiltinMethod(allocator: Allocator, builtin_name: []const u8, method: GodotApi.Builtin.Method, ctx: *const Context) !Function {
     var self = Function{};
     errdefer self.deinit(allocator);
 
-    self.doc = if (method.description) |doc| try docs.convertDocsToMarkdown(allocator, doc, ctx, .{}) else null;
+    self.doc = if (method.description) |doc| try docs.convertDocsToMarkdown(allocator, doc, ctx, .{
+        .current_class = builtin_name,
+    }) else null;
     self.name = try case.allocTo(allocator, .camel, method.name);
     self.name_api = method.name;
     self.hash = method.hash;
@@ -85,11 +89,13 @@ pub fn fromBuiltinMethod(allocator: Allocator, method: GodotApi.Builtin.Method, 
     return self;
 }
 
-pub fn fromClass(allocator: Allocator, api: GodotApi.Class.Method, ctx: *const Context) !Function {
+pub fn fromClass(allocator: Allocator, class_name: []const u8, api: GodotApi.Class.Method, ctx: *const Context) !Function {
     var self = Function{};
     errdefer self.deinit(allocator);
 
-    self.doc = if (api.description) |doc| try docs.convertDocsToMarkdown(allocator, doc, ctx, .{}) else null;
+    self.doc = if (api.description) |doc| try docs.convertDocsToMarkdown(allocator, doc, ctx, .{
+        .current_class = class_name,
+    }) else null;
     self.name = blk: {
         if (!api.is_virtual) {
             break :blk try case.allocTo(allocator, .camel, api.name);

--- a/bindgen/Context/Function.zig
+++ b/bindgen/Context/Function.zig
@@ -20,7 +20,7 @@ pub fn fromBuiltinConstructor(allocator: Allocator, builtin_name: []const u8, co
     var self = Function{};
     errdefer self.deinit(allocator);
 
-    self.doc = if (constructor.description) |doc| try docs.convertDocsToMarkdown(allocator, doc, ctx) else null;
+    self.doc = if (constructor.description) |doc| try docs.convertDocsToMarkdown(allocator, doc, ctx, .{}) else null;
     self.name = blk: {
         var buf: ArrayList(u8) = .empty;
         errdefer buf.deinit(allocator);
@@ -65,7 +65,7 @@ pub fn fromBuiltinMethod(allocator: Allocator, method: GodotApi.Builtin.Method, 
     var self = Function{};
     errdefer self.deinit(allocator);
 
-    self.doc = if (method.description) |doc| try docs.convertDocsToMarkdown(allocator, doc, ctx) else null;
+    self.doc = if (method.description) |doc| try docs.convertDocsToMarkdown(allocator, doc, ctx, .{}) else null;
     self.name = try case.allocTo(allocator, .camel, method.name);
     self.name_api = method.name;
     self.hash = method.hash;
@@ -89,7 +89,7 @@ pub fn fromClass(allocator: Allocator, api: GodotApi.Class.Method, ctx: *const C
     var self = Function{};
     errdefer self.deinit(allocator);
 
-    self.doc = if (api.description) |doc| try docs.convertDocsToMarkdown(allocator, doc, ctx) else null;
+    self.doc = if (api.description) |doc| try docs.convertDocsToMarkdown(allocator, doc, ctx, .{}) else null;
     self.name = blk: {
         if (!api.is_virtual) {
             break :blk try case.allocTo(allocator, .camel, api.name);
@@ -189,7 +189,7 @@ pub fn fromUtilityFunction(allocator: Allocator, function: GodotApi.UtilityFunct
     var self: Function = .{};
     errdefer self.deinit(allocator);
 
-    self.doc = if (function.description) |desc| try docs.convertDocsToMarkdown(allocator, desc, ctx) else null;
+    self.doc = if (function.description) |desc| try docs.convertDocsToMarkdown(allocator, desc, ctx, .{}) else null;
     self.name = try case.allocTo(allocator, .camel, function.name);
     self.name_api = function.name;
     self.hash = function.hash;

--- a/bindgen/Context/Module.zig
+++ b/bindgen/Context/Module.zig
@@ -22,4 +22,3 @@ const std = @import("std");
 const Allocator = std.mem.Allocator;
 
 const Context = @import("../Context.zig");
-const GodotApi = @import("../GodotApi.zig");

--- a/bindgen/Context/docs.zig
+++ b/bindgen/Context/docs.zig
@@ -152,7 +152,7 @@ pub const DocumentContext = struct {
             }
         }
 
-        logger.err("Enum symbol lookup failed: {s}", .{enum_name});
+        logger.err("Enum symbol lookup failed: {s}, current class: {s}", .{ enum_name, self.current_class orelse "unknown" });
         try self.writer.print("`{s}`", .{enum_name});
         return true;
     }

--- a/bindgen/Context/docs.zig
+++ b/bindgen/Context/docs.zig
@@ -62,8 +62,8 @@ pub const DocumentContext = struct {
 
     fn resolveEnum(self: DocumentContext, enum_name: []const u8) ?[]const u8 {
         if (self.current_class) |class_name| {
-            const qualified = std.fmt.allocPrint(self.codegen_ctx.allocator, "{s}.{s}", .{ class_name, enum_name }) catch return null;
-            defer self.codegen_ctx.allocator.free(qualified);
+            const qualified = std.fmt.allocPrint(self.codegen_ctx.getRawAllocator(), "{s}.{s}", .{ class_name, enum_name }) catch return null;
+            defer self.codegen_ctx.getRawAllocator().free(qualified);
 
             // Check if this qualified name exists in symbol_lookup
             if (self.symbolLookup(qualified)) |link| {
@@ -76,8 +76,8 @@ pub const DocumentContext = struct {
 
     fn resolveMethod(self: *const DocumentContext, method_name: []const u8) ?[]const u8 {
         if (self.current_class) |class_name| {
-            const qualified = std.fmt.allocPrint(self.codegen_ctx.allocator, "{s}.{s}", .{ class_name, method_name }) catch return null;
-            defer self.codegen_ctx.allocator.free(qualified);
+            const qualified = std.fmt.allocPrint(self.codegen_ctx.getRawAllocator(), "{s}.{s}", .{ class_name, method_name }) catch return null;
+            defer self.codegen_ctx.getRawAllocator().free(qualified);
 
             // Check if this qualified name exists in symbol_lookup
             if (self.symbolLookup(qualified)) |link| {
@@ -154,8 +154,8 @@ pub const DocumentContext = struct {
     }
 
     pub fn writeCodeblocks(self: DocumentContext, node: Node) anyerror!bool {
-        var element_list = try node.childrenOfType(self.codegen_ctx.allocator, .element);
-        defer element_list.deinit(self.codegen_ctx.allocator);
+        var element_list = try node.childrenOfType(self.codegen_ctx.getRawAllocator(), .element);
+        defer element_list.deinit(self.codegen_ctx.getRawAllocator());
 
         for (element_list.items) |child| {
             const lang = try child.getName();

--- a/bindgen/Context/docs.zig
+++ b/bindgen/Context/docs.zig
@@ -96,19 +96,29 @@ pub const DocumentContext = struct {
             try symbol_lookup.putNoClobber(ctx.allocator, "Variant", "Variant");
 
             for (api.classes) |class| {
+                if (util.shouldSkipClass(class.name)) continue;
+
                 const doc_name = try std.fmt.allocPrint(ctx.allocator, "bindings.core.{s}", .{class.name});
                 try symbol_lookup.putNoClobber(ctx.allocator, class.name, doc_name);
 
                 for (class.enums orelse &.{}) |@"enum"| {
                     const enum_name = try std.fmt.allocPrint(ctx.allocator, "{s}.{s}", .{ class.name, @"enum".name });
-                    const enum_doc_name = try std.fmt.allocPrint(ctx.allocator, "bindings.core.{s}.{s}", .{ class.name, enum_name });
+                    const enum_doc_name = try std.fmt.allocPrint(ctx.allocator, "{s}.{s}", .{ doc_name, enum_name });
                     try symbol_lookup.putNoClobber(ctx.allocator, enum_name, enum_doc_name);
                 }
             }
 
             for (api.builtin_classes) |builtin| {
-                const doc_name = try std.fmt.allocPrint(ctx.allocator, "bindings.core.{s}", .{builtin.name});
+                if (util.shouldSkipClass(builtin.name)) continue;
+
+                const doc_name = try std.fmt.allocPrint(ctx.allocator, "bindings.core.{0s}", .{builtin.name});
                 try symbol_lookup.putNoClobber(ctx.allocator, builtin.name, doc_name);
+
+                for (builtin.enums orelse &.{}) |@"enum"| {
+                    const enum_name = try std.fmt.allocPrint(ctx.allocator, "{s}.{s}", .{ builtin.name, @"enum".name });
+                    const enum_doc_name = try std.fmt.allocPrint(ctx.allocator, "{s}.{s}", .{ doc_name, enum_name });
+                    try symbol_lookup.putNoClobber(ctx.allocator, enum_name, enum_doc_name);
+                }
             }
 
             for (api.global_enums) |@"enum"| {
@@ -315,4 +325,6 @@ const StringHashMap = std.StringHashMapUnmanaged;
 const std = @import("std");
 const testing = std.testing;
 const bbcodez = @import("bbcodez");
+const util = @import("../util.zig");
+
 const logger = std.log.scoped(.docs);

--- a/bindgen/Context/type.zig
+++ b/bindgen/Context/type.zig
@@ -91,6 +91,4 @@ const std = @import("std");
 const Allocator = mem.Allocator;
 const mem = std.mem;
 
-const precision = @import("build_options").precision;
-
 const Context = @import("../Context.zig");

--- a/bindgen/codegen.zig
+++ b/bindgen/codegen.zig
@@ -13,9 +13,7 @@ fn writeBuiltins(ctx: *const Context) !void {
             continue;
         }
 
-        const filename = try std.fmt.allocPrint(ctx.allocator, "{s}.zig", .{builtin.name});
-        defer ctx.allocator.free(filename);
-
+        const filename = try std.fmt.allocPrint(ctx.arena.allocator(), "{s}.zig", .{builtin.name});
         const file = try ctx.config.output.createFile(filename, .{});
         defer file.close();
 
@@ -219,8 +217,8 @@ fn writeClasses(ctx: *const Context) !void {
             continue;
         }
 
-        const filename = try std.fmt.allocPrint(ctx.allocator, "{s}.zig", .{class.name});
-        defer ctx.allocator.free(filename);
+        const filename = try std.fmt.allocPrint(ctx.getRawAllocator(), "{s}.zig", .{class.name});
+        defer ctx.getRawAllocator().free(filename);
 
         const file = try ctx.config.output.createFile(filename, .{});
         defer file.close();
@@ -707,8 +705,8 @@ fn writeImports(w: *Writer, imports: *const Context.Imports) !void {
 
 fn writeModules(ctx: *const Context) !void {
     for (ctx.modules.values()) |*module| {
-        const filename = try std.fmt.allocPrint(ctx.allocator, "{s}.zig", .{module.name});
-        defer ctx.allocator.free(filename);
+        const filename = try std.fmt.allocPrint(ctx.getRawAllocator(), "{s}.zig", .{module.name});
+        defer ctx.getRawAllocator().free(filename);
 
         const file = try ctx.config.output.createFile(filename, .{});
         defer file.close();

--- a/bindgen/codegen.zig
+++ b/bindgen/codegen.zig
@@ -1011,12 +1011,10 @@ pub const ProcType = enum {
 
 const std = @import("std");
 const bufferedWriter = std.io.bufferedWriter;
-const StringHashMap = std.StringHashMapUnmanaged;
 
 const gdextension = @import("gdextension");
 
 const Context = @import("Context.zig");
-const GodotApi = @import("GodotApi.zig");
 const Writer = @import("writer.zig").AnyWriter;
 const codeWriter = @import("writer.zig").codeWriter;
 const util = @import("util.zig");

--- a/bindgen/packed_array.zig
+++ b/bindgen/packed_array.zig
@@ -1,10 +1,6 @@
 const std = @import("std");
 const mzvr = @import("mvzr");
-const GodotApi = @import("GodotApi.zig");
 const case = @import("case");
-
-const Config = @import("Config.zig");
-const Context = @import("Context.zig");
 
 const PackedArrayType = enum {
     byte,

--- a/bindgen/writer.zig
+++ b/bindgen/writer.zig
@@ -106,7 +106,6 @@ pub fn CodeWriter(comptime W: type) type {
 }
 
 const std = @import("std");
-const io = std.io;
 const testing = std.testing;
 
 test "indents" {

--- a/src/Variant.zig
+++ b/src/Variant.zig
@@ -228,8 +228,6 @@ const meta = std.meta;
 
 const precision = @import("build_options").precision;
 
-const gdext = @import("gdextension");
-
 const vector = @import("vector");
 const Vector2 = vector.Vector2;
 const Vector2i = vector.Vector2i;

--- a/src/debug.zig
+++ b/src/debug.zig
@@ -49,8 +49,6 @@ pub inline fn assertVariantLike(comptime T: type) void {
 }
 
 const std = @import("std");
-const debug = std.debug;
 const fmt = std.fmt;
-const mem = std.mem;
 
 const godot = @import("root.zig");

--- a/src/meta.zig
+++ b/src/meta.zig
@@ -127,9 +127,7 @@ pub fn Deref(comptime T: type) type {
 }
 
 const std = @import("std");
-const debug = std.debug;
 const fmt = std.fmt;
-const mem = std.mem;
 const Tuple = std.meta.Tuple;
 
 const godot = @import("root.zig");


### PR DESCRIPTION
This refactors the documentation conversion system to use a dedicated DocumentContext struct that handles symbol lookup and link generation. 