### PR TITLE
refactor: replace "godot_object: *anyopaque" field with "base: T"

### DIFF
--- a/example/src/ExampleNode.zig
+++ b/example/src/ExampleNode.zig
@@ -23,7 +23,7 @@ pub fn init(self: *Self) void {
 
     self.fps_counter = Label.init();
     self.fps_counter.setPosition(.{ .x = 50, .y = 50 }, .{});
-    self.base.addChild(Node.cast(self.fps_counter).?, .{});
+    self.base.addChild(.upcast(self.fps_counter), .{});
 }
 
 pub fn deinit(self: *Self) void {
@@ -47,7 +47,7 @@ pub fn _process(self: *Self, delta: f64) void {
 
 fn clearScene(self: *Self) void {
     if (self.example_node) |n| {
-        godot.destroy(n);
+        godot.object.destroy(n);
         //n.queue_free(); //ok
     }
 }
@@ -64,9 +64,9 @@ pub fn onItemFocused(self: *Self, idx: i64) void {
     self.clearScene();
     switch (idx) {
         inline 0...Examples.len - 1 => |i| {
-            const n = godot.create(Examples[i].T) catch unreachable;
-            self.example_node = godot.cast(Node, n.base);
-            self.panel.addChild(Node.cast(self.example_node.?).?, .{});
+            const n = godot.object.create(Examples[i].T) catch unreachable;
+            self.example_node = .upcast(n);
+            self.panel.addChild(self.example_node.?, .{});
             self.panel.grabFocus();
         },
         else => {},
@@ -107,9 +107,9 @@ pub fn _enterTree(self: *Self) void {
     self.panel.setHSizeFlags(.{ .size_fill = true });
     self.panel.setVSizeFlags(.{ .size_fill = true });
     self.panel.setFocusMode(.focus_all);
-    sp.addChild(Node.cast(itemList).?, .{});
-    sp.addChild(Node.cast(self.panel).?, .{});
-    self.base.addChild(Node.cast(sp).?, .{});
+    sp.addChild(.upcast(itemList), .{});
+    sp.addChild(.upcast(self.panel), .{});
+    self.base.addChild(.upcast(sp), .{});
 
     const vprt = self.base.getViewport().?;
     const tex = vprt.getTexture().?;

--- a/example/src/GuiNode.zig
+++ b/example/src/GuiNode.zig
@@ -7,13 +7,13 @@ pub fn _enterTree(self: *Self) void {
     if (Engine.isEditorHint()) return;
 
     var normal_btn = Button.init();
-    self.base.addChild(Node.cast(normal_btn).?, .{});
+    self.base.addChild(.upcast(normal_btn), .{});
     normal_btn.setPosition(Vector2.new(100, 20), .{});
     normal_btn.setSize(Vector2.new(100, 50), .{});
     normal_btn.setText(.fromLatin1("Press Me"));
 
     var toggle_btn = CheckBox.init();
-    self.base.addChild(Node.cast(toggle_btn).?, .{});
+    self.base.addChild(.upcast(toggle_btn), .{});
     toggle_btn.setPosition(.new(320, 20), .{});
     toggle_btn.setSize(.new(100, 50), .{});
     toggle_btn.setText(.fromLatin1("Toggle Me"));
@@ -25,10 +25,10 @@ pub fn _enterTree(self: *Self) void {
     const texture = ResourceLoader.load(res_name, .{}).?;
     defer _ = texture.unreference();
     self.sprite = Sprite2D.init();
-    self.sprite.setTexture(Texture2D.cast(texture).?);
+    self.sprite.setTexture(Texture2D.downcast(texture) catch unreachable);
     self.sprite.setPosition(.new(400, 300));
     self.sprite.setScale(.new(0.6, 0.6));
-    self.base.addChild(Node.cast(self.sprite).?, .{});
+    self.base.addChild(.upcast(self.sprite), .{});
 }
 
 pub fn _exitTree(self: *Self) void {

--- a/example/src/SignalNode.zig
+++ b/example/src/SignalNode.zig
@@ -20,25 +20,25 @@ pub fn _enterTree(self: *Self) void {
     signal1_btn.setPosition(.new(100, 20), .{});
     signal1_btn.setSize(.new(100, 50), .{});
     signal1_btn.setText(.fromLatin1("Signal1"));
-    self.base.addChild(Node.cast(signal1_btn).?, .{});
+    self.base.addChild(.upcast(signal1_btn), .{});
 
     var signal2_btn = Button.init();
     signal2_btn.setPosition(.new(250, 20), .{});
     signal2_btn.setSize(.new(100, 50), .{});
     signal2_btn.setText(.fromLatin1("Signal2"));
-    self.base.addChild(Node.cast(signal2_btn).?, .{});
+    self.base.addChild(.upcast(signal2_btn), .{});
 
     var signal3_btn = Button.init();
     signal3_btn.setPosition(.new(400, 20), .{});
     signal3_btn.setSize(.new(100, 50), .{});
     signal3_btn.setText(.fromLatin1("Signal3"));
-    self.base.addChild(Node.cast(signal3_btn).?, .{});
+    self.base.addChild(.upcast(signal3_btn), .{});
 
     self.color_rect = ColorRect.init();
     self.color_rect.setPosition(.new(400, 400), .{});
     self.color_rect.setSize(.new(100, 100), .{});
     self.color_rect.setColor(.initRGBA(1, 0, 0, 1));
-    self.base.addChild(Node.cast(self.color_rect).?, .{});
+    self.base.addChild(.upcast(self.color_rect), .{});
 
     godot.connect(signal1_btn, "pressed", self, "emitSignal1");
     godot.connect(signal2_btn, "pressed", self, "emitSignal2");

--- a/example/src/SpriteNode.zig
+++ b/example/src/SpriteNode.zig
@@ -41,10 +41,10 @@ pub fn _ready(self: *Self) void {
             .scale = Vector2.set(s),
             .gd_sprite = Sprite2D.init(),
         };
-        spr.gd_sprite.setTexture(Texture2D.cast(tex).?);
+        spr.gd_sprite.setTexture(Texture2D.downcast(tex) catch unreachable);
         spr.gd_sprite.setRotation(self.randfRange(f32, 0, std.math.pi));
         spr.gd_sprite.setScale(spr.scale);
-        self.base.addChild(Node.cast(spr.gd_sprite).?, .{});
+        self.base.addChild(.upcast(spr.gd_sprite), .{});
         self.sprites.append(spr) catch unreachable;
     }
 }

--- a/src/Variant.zig
+++ b/src/Variant.zig
@@ -38,13 +38,13 @@ pub const Variant = extern struct {
             // TODO: GDExtensionInstanceBindingCallbacks?
             const instance: *Object = @ptrCast(@alignCast(godot.coreobjectGetInstanceBinding(ptr, godot.core.p_library, null)));
 
-            if (meta.Child(T) == Object) {
+            if (std.meta.Child(T) == Object) {
                 return instance;
             } else {
-                const class_name = godot.getClassName(meta.Child(T));
+                const class_name = godot.getClassName(std.meta.Child(T));
                 const class_tag = godot.core.classdbGetClassTag(@ptrCast(class_name));
                 // TODO: this can return null if its not the right type; return type should be optional depending on T, right? or return error?
-                const casted = godot.core.objectCastTo(instance.godot_object, class_tag);
+                const casted = godot.core.objectCastTo(meta.asObjectPtr(instance), class_tag);
                 const binding = godot.core.objectGetInstanceBinding(casted, godot.core.p_library, null);
 
                 return @ptrCast(@alignCast(binding));
@@ -224,7 +224,8 @@ pub const Variant = extern struct {
 const std = @import("std");
 const Atomic = std.atomic.Value;
 const mem = std.mem;
-const meta = std.meta;
+
+const meta = @import("meta.zig");
 
 const precision = @import("build_options").precision;
 

--- a/src/debug.zig
+++ b/src/debug.zig
@@ -1,46 +1,46 @@
-pub inline fn assertIs(comptime T: type, comptime U: type) void {
-    comptime {
-        if (!godot.meta.isA(T, U)) {
-            const message = fmt.comptimePrint("expected type '{s}', found '{s}'", .{ @typeName(T), @typeName(U) });
-            @compileError(message);
-        }
+pub fn assertIs(comptime T: type, comptime U: type) void {
+    if (comptime !godot.meta.isA(T, U)) {
+        const message = fmt.comptimePrint("expected type '{s}', found '{s}'", .{ @typeName(T), @typeName(U) });
+        @compileError(message);
     }
 }
 
-pub inline fn assertIsAny(comptime types: anytype, comptime U: type) void {
-    comptime {
-        if (!godot.meta.isAny(types, U)) {
-            var names: []const u8 = "";
-            for (if (@hasField(types, "len")) types else .{types}, 0..) |t, i| {
-                if (i == 0) {
-                    names = names ++ "'" ++ @typeName(t) ++ "'";
-                } else if (i == types.len - 1) {
-                    names = names ++ ", or '" ++ @typeName(t) ++ "'";
-                } else {
-                    names = names ++ ", '" ++ @typeName(t) ++ "'";
-                }
+pub fn assertIsAny(comptime types: anytype, comptime U: type) void {
+    if (comptime !godot.meta.isAny(types, U)) {
+        var names: []const u8 = "";
+        for (if (@hasField(types, "len")) types else .{types}, 0..) |t, i| {
+            if (i == 0) {
+                names = names ++ "'" ++ @typeName(t) ++ "'";
+            } else if (i == types.len - 1) {
+                names = names ++ ", or '" ++ @typeName(t) ++ "'";
+            } else {
+                names = names ++ ", '" ++ @typeName(t) ++ "'";
             }
-            const message = fmt.comptimePrint("expected type {s}, found '{s}'", .{ names, @typeName(U) });
-            @compileError(message);
         }
+        const message = fmt.comptimePrint("expected type {s}, found '{s}'", .{ names, @typeName(U) });
+        @compileError(message);
     }
 }
 
-pub inline fn assertPathLike(comptime T: type) void {
+pub fn assertIsObject(comptime T: type) void {
+    assertIs(godot.core.Object, T);
+}
+
+pub fn assertPathLike(comptime T: type) void {
     assertIsAny(
         .{ godot.core.NodePath, []const u8, [:0]const u8 },
         T,
     );
 }
 
-pub inline fn assertStringLike(comptime T: type) void {
+pub fn assertStringLike(comptime T: type) void {
     assertIsAny(
         .{ godot.core.String, godot.core.StringName, []const u8, [:0]const u8 },
         T,
     );
 }
 
-pub inline fn assertVariantLike(comptime T: type) void {
+pub fn assertVariantLike(comptime T: type) void {
     // TODO: other types
     assertIsAny(
         .{godot.core.Variant},

--- a/src/heap.zig
+++ b/src/heap.zig
@@ -19,37 +19,10 @@ pub fn free(ptr: ?*anyopaque) void {
     }
 }
 
-pub fn create(comptime T: type) !*T {
-    const self = try godot.general_allocator.create(T);
-    self.base = .{ .godot_object = core.classdbConstructObject2(@ptrCast(godot.getParentClassName(T))) };
-    core.objectSetInstance(self.base.godot_object, @ptrCast(godot.getClassName(T)), @ptrCast(self));
-    core.objectSetInstanceBinding(self.base.godot_object, godot.p_library, @ptrCast(self), @ptrCast(&godot.dummy_callbacks));
-    if (@hasDecl(T, "init")) {
-        self.init();
-    }
-    return self;
-}
-
-pub fn recreate(comptime T: type, obj: *anyopaque) !*T {
-    const self = try godot.general_allocator.create(T);
-    self.* = std.mem.zeroInit(T, .{});
-    self.base = @bitCast(Object{ .ptr = obj });
-    core.objectSetInstance(self.base.godot_object, @ptrCast(godot.getClassName(T)), @ptrCast(self));
-    core.objectSetInstanceBinding(self.base.godot_object, godot.p_library, @ptrCast(self), @ptrCast(&godot.dummy_callbacks));
-    if (@hasDecl(T, "init")) {
-        self.init();
-    }
-    return self;
-}
-
-pub fn destroy(object: anytype) void {
-    core.objectFreeInstanceBinding(meta.asObjectPtr(object), godot.p_library);
-    core.objectDestroy(meta.asObjectPtr(object));
-}
-
 const std = @import("std");
 
 const godot = @import("root.zig");
 const core = godot.core;
+const debug = godot.debug;
 const meta = godot.meta;
 const Object = godot.core.Object;

--- a/src/meta.zig
+++ b/src/meta.zig
@@ -65,18 +65,6 @@ pub fn isAny(comptime types: anytype, comptime U: type) bool {
     return false;
 }
 
-pub fn cast(comptime T: type, value: anytype) ?T {
-    const U = if (@TypeOf(value) == type) value else @TypeOf(value);
-
-    if (comptime isA(T, U)) {
-        return upcast(T, value);
-    } else if (comptime isA(U, T)) {
-        return downcast(T, value);
-    } else {
-        @compileError("cannot cast from '" ++ @typeName(U) ++ "' to " ++ @typeName(T));
-    }
-}
-
 pub fn upcast(comptime T: type, value: anytype) T {
     const Dereffed = Deref(@TypeOf(value));
     if (comptime Dereffed == T) {

--- a/src/object.zig
+++ b/src/object.zig
@@ -1,0 +1,59 @@
+/// Create a Godot object.
+pub fn create(comptime T: type) !*T {
+    // TODO: I don't think this class can handle nested user types (MyType { base: Node } and MyTypeSubtype { base: MyType })
+    debug.assertIsObject(T);
+
+    const class_name = meta.getNamePtr(T);
+    const base_name = meta.getNamePtr(meta.BaseOf(T));
+
+    // TODO: shouldn't we use Godot's allocator? can this be done without a double allocation?
+    const ptr = core.classdbConstructObject2(@ptrCast(base_name)).?;
+    const self = try godot.general_allocator.create(T);
+
+    // Store the pointer on base type
+    if (T == core.Object) {
+        self.ptr = ptr;
+    } else {
+        self.base = @bitCast(core.Object{ .ptr = ptr });
+    }
+
+    core.objectSetInstance(ptr, @ptrCast(class_name), @ptrCast(self));
+    core.objectSetInstanceBinding(ptr, core.p_library, @ptrCast(self), @ptrCast(&godot.dummy_callbacks));
+
+    // TODO: doesn't Godot call `_init`? shouldn't we let `init` call `heap.create()`?
+    //       Proper hierarchy of control is not clear here
+    if (@hasDecl(T, "init")) {
+        self.init();
+    }
+
+    return self;
+}
+
+/// Recreate a Godot object.
+pub fn recreate(comptime T: type, ptr: ?*anyopaque) !*T {
+    debug.assertIsObject(T);
+    _ = ptr;
+    @panic("Extension reloading is not currently supported");
+}
+
+/// Destroy a Godot object.
+pub fn destroy(instance: anytype) void {
+    debug.assertIsObject(@TypeOf(instance));
+
+    const ptr = meta.asObjectPtr(instance);
+    core.objectFreeInstanceBinding(ptr, core.p_library);
+    core.objectDestroy(ptr);
+}
+
+/// Unreference a Godot object.
+pub fn unreference(instance: anytype) void {
+    if (meta.asRefCounted(instance).unreference()) {
+        core.objectDestroy(meta.asObjectPtr(instance));
+    }
+}
+
+const godot = @import("root.zig");
+const core = godot.core;
+const debug = godot.debug;
+const meta = godot.meta;
+const Object = core.Object;

--- a/src/support.zig
+++ b/src/support.zig
@@ -19,7 +19,7 @@ pub inline fn bindClassMethod(
 ) ClassMethod {
     const callback = struct {
         fn callback(string_name: core.StringName) ClassMethod {
-            const class_name = godot.getClassName(T);
+            const class_name = godot.meta.getNamePtr(T);
             return core.classdbGetMethodBind(@ptrCast(class_name), @ptrCast(@constCast(&string_name)), hash).?;
         }
     }.callback;


### PR DESCRIPTION
this change enables support for zero cost upcasting (e.g. `MyNode` to `Object`) with comptime type checking, enabling improved statically with statically typed parameters. instead of:

```zig
scene.addChild(Node.cast(my_node).?, .{});
```

we have:

```zig
scene.addChild(.upcast(my_node), .{});
```

downcasting (e.g. `Object` to `MyNode`) will always incur a runtime cost and have to return an optional `?T`, because there is no guarantee that the value is an instance of the child type. however, we now also have comptime typechecking where possible (e.g. cannot downcast `Animal` to `House`)