### PR TITLE
fix: pass self to builtin methods as pointer

### DIFF
--- a/bindgen/Context/Class.zig
+++ b/bindgen/Context/Class.zig
@@ -106,11 +106,13 @@ pub fn fromApi(allocator: Allocator, api: GodotApi.Class, ctx: *const Context) !
             var inherited: Function = function.*;
 
             // Update the self type to this class
-            if (inherited.self == .constant) {
-                inherited.self = .{ .constant = self.name };
-            } else if (inherited.self == .mutable) {
-                inherited.self = .{ .mutable = self.name };
-            }
+            inherited.self = switch (inherited.self) {
+                .static => .static,
+                .singleton => .singleton,
+                .constant => |_| .{ .constant = self.name },
+                .mutable => |_| .{ .mutable = self.name },
+                .value => |_| .{ .value = self.name },
+            };
 
             // Convert the function to a singleton function if we are a singleton and the parent is not
             if (self.is_singleton and inherited.self != .static and inherited.self != .singleton) {

--- a/bindgen/Context/Function.zig
+++ b/bindgen/Context/Function.zig
@@ -23,10 +23,12 @@ self: union(enum) {
     static: void,
     /// This function takes a singleton instance.
     singleton: void,
-    /// This function takes a constant instance.
+    /// This function takes a constant self pointer.
     constant: []const u8,
-    /// This function takes a mutable self instance.
+    /// This function takes a mutable self pointer.
     mutable: []const u8,
+    /// This function takes self by value.
+    value: []const u8,
 } = .static,
 is_vararg: bool = false,
 
@@ -244,7 +246,7 @@ pub fn fromClass(allocator: Allocator, class_name: []const u8, has_singleton: bo
     else if (api.is_const)
         .{ .constant = class_name }
     else
-        .{ .mutable = class_name };
+        .{ .value = class_name };
     self.is_vararg = api.is_vararg;
 
     for (api.arguments orelse &.{}) |arg| {
@@ -305,7 +307,7 @@ pub fn fromClassSetter(allocator: Allocator, class_name: []const u8, is_singleto
     self.name = try case.allocTo(allocator, .camel, name);
     self.name_api = name;
     self.base = class_name;
-    self.self = if (is_singleton) .singleton else .{ .mutable = class_name };
+    self.self = if (is_singleton) .singleton else .{ .value = class_name };
     self.is_vararg = false;
     self.return_type = .void;
 

--- a/bindgen/codegen.zig
+++ b/bindgen/codegen.zig
@@ -231,6 +231,7 @@ fn writeBuiltinMethod(w: *Writer, builtin_name: []const u8, method: *const Conte
             .singleton => @panic("singleton builtins not supported"),
             .constant => "@ptrCast(@constCast(self))",
             .mutable => "@ptrCast(self)",
+            .value => "@ptrCast(@constCast(&self))",
         },
     });
     try writeFunctionFooter(w, method);
@@ -689,15 +690,19 @@ fn writeFunctionHeader(w: *Writer, function: *const Context.Function) !void {
 
     // Self parameter
     switch (function.self) {
+        .static, .singleton => {},
         .constant => |self| {
             try w.print("self: *const {0s}", .{self});
             is_first = false;
         },
         .mutable => |self| {
+            try w.print("self: *{0s}", .{self});
+            is_first = false;
+        },
+        .value => |self| {
             try w.print("self: {0s}", .{self});
             is_first = false;
         },
-        else => {},
     }
 
     // Positional parameters


### PR DESCRIPTION
builtins are actual value types. mutation will require `*Self`.

whereas, classes are pointer wrappers (`struct { ptr: *anyopaque }`). they should just copy the pointer in with `Self`.