### PR TITLE
fix: segfault while generating docs

### DIFF
--- a/bindgen/Context/Class.zig
+++ b/bindgen/Context/Class.zig
@@ -42,7 +42,6 @@ imports: Imports = .empty,
 
 pub fn fromApi(allocator: Allocator, api: GodotApi.Class, ctx: *const Context) !Class {
     var self: Class = .{};
-    errdefer self.deinit(allocator);
 
     // Documentation
     self.doc = if (api.description) |desc|

--- a/bindgen/Context/Function.zig
+++ b/bindgen/Context/Function.zig
@@ -221,7 +221,6 @@ pub fn fromBuiltinMethod(allocator: Allocator, builtin_name: []const u8, api: Go
 
 pub fn fromClass(allocator: Allocator, class_name: []const u8, has_singleton: bool, api: GodotApi.Class.Method, ctx: *const Context) !Function {
     var self = Function{};
-    errdefer self.deinit(allocator);
 
     self.doc = if (api.description) |doc| try docs.convertDocsToMarkdown(allocator, doc, ctx, .{
         .current_class = class_name,


### PR DESCRIPTION
# Summary

`[param <name>]` tags in the docs was causing segfaults and I had no idea why. Turns out I wasn't checking the node type before processing them assuming they were `element` tags. There just happens to be a `text` node with the text "method". This matches an `Element` enum value.  


## Note 
Those `errdefer`s are good intentioned but they sent me down the wrong rabbit hole. The `deinit` functions would need to be able to know which things need freeing. 