### PR TITLE
fix: align method return ptr

### DIFF
--- a/gdzig/support.zig
+++ b/gdzig/support.zig
@@ -119,7 +119,7 @@ pub fn MethodBinderT(comptime MethodType: type) type {
                 if (ReturnType == void or ReturnType == null) {
                     @call(.auto, method, .{});
                 } else {
-                    @as(*Variant, @ptrCast(p_return)).* = Variant.init(@call(.auto, method, .{}));
+                    @as(*Variant, @ptrCast(@alignCast(p_return))).* = Variant.init(@call(.auto, method, .{}));
                 }
             } else {
                 var variants: [ArgCount - 1]Variant = undefined;
@@ -135,7 +135,7 @@ pub fn MethodBinderT(comptime MethodType: type) type {
                 if (ReturnType == void or ReturnType == null) {
                     @call(.auto, method, args);
                 } else {
-                    @as(*Variant, @ptrCast(p_return)).* = Variant.init(@call(.auto, method, args));
+                    @as(*Variant, @ptrCast(@alignCast(p_return))).* = Variant.init(@call(.auto, method, args));
                 }
             }
         }


### PR DESCRIPTION
There is a compile error related to failing to cast `*anyopaque` to `*Variant` for the return value of methods. This is just missing the `@alignCast`.

Example class which causes the build error:
```zig
const GdzigExample = @This();
const godot = @import("gdzig");
const Node = godot.class.Node;
const my_value: f64 = 2.25;

base: *Node,

pub fn init(base: *Node) GdzigExample {
    return .{ .base = base };
}

pub fn getMyValue(_: *GdzigExample) f64 {
    return my_value;
}

pub fn _bindMethods() void {
    godot.registerMethod(GdzigExample, "getMyValue");
}

```

Error:
```
install
└─ install zigtest
   └─ compile lib zigtest Debug native 1 errors
.zig-cache/o/d66d25a25ebe215956fdc9263fb9f53d/gdzig/support.zig:138:35: error: @ptrCast increases pointer alignment
                    @as(*Variant, @ptrCast(p_return)).* = Variant.init(@call(.auto, method, args));
                                  ^~~~~~~~~~~~~~~~~~
.zig-cache/o/d66d25a25ebe215956fdc9263fb9f53d/gdzig/support.zig:138:44: note: '?*anyopaque' has alignment '1'
                    @as(*Variant, @ptrCast(p_return)).* = Variant.init(@call(.auto, method, args));
                                           ^~~~~~~~
.zig-cache/o/d66d25a25ebe215956fdc9263fb9f53d/gdzig/support.zig:138:35: note: '*builtin.variant.Variant' has alignment '8'
.zig-cache/o/d66d25a25ebe215956fdc9263fb9f53d/gdzig/support.zig:138:35: note: use @alignCast to assert pointer alignment
```