### PR TITLE
feat(exports): add GDScript-like property exports

### DIFF
--- a/example/src/ExampleNode.zig
+++ b/example/src/ExampleNode.zig
@@ -15,9 +15,9 @@ property2: Vector3 = .zero,
 
 fps_counter: *Label,
 
-pub const __exports = .{
-    .{ .@"export", .property1 },
-    .{ .@"export", .property2, "hint2" },
+pub const __exports = [_]Export{
+    .{ .property = .{ .field = .property1 } },
+    .{ .property = .{ .field = .property2, .hint = "hint2" } },
 };
 
 pub fn init(base: *Node) ExampleNode {
@@ -157,6 +157,7 @@ pub fn _bindMethods() void {
 const std = @import("std");
 
 const godot = @import("gdzig");
+const Export = godot.Export;
 const Engine = godot.class.Engine;
 const HSplitContainer = godot.class.HSplitContainer;
 const ItemList = godot.class.ItemList;

--- a/gdzig/exports.zig
+++ b/gdzig/exports.zig
@@ -9,162 +9,216 @@ const PropertyUsageFlags = godot.global.PropertyUsageFlags;
 const heap = godot.heap;
 const c = godot.c;
 
-const ExportType = enum {
-    @"export",
-    @"export_group",
-    @"export_subgroup",
-    @"export_category",
-    @"export_range",
-    @"export_exp_easing",
-    @"export_enum",
-    @"export_flags",
-    @"export_flags_2d_physics",
-    @"export_flags_2d_render",
-    @"export_flags_2d_navigation",
-    @"export_flags_3d_physics",
-    @"export_flags_3d_render",
-    @"export_flags_3d_navigation",
-    @"export_file",
-    @"export_dir",
-    @"export_global_file",
-    @"export_global_dir",
-    @"export_multiline",
-    @"export_placeholder",
-    @"export_color_no_alpha",
-    @"export_node_path",
-    @"export_storage",
-    @"export_custom",
-};
+pub const Export = union(enum) {
+    const Field = @TypeOf(.enum_literal);
 
-fn getExportType(comptime entry: anytype) ExportType {
-    const first = entry[0];
-    const FirstType = @TypeOf(first);
+    property: struct {
+        field: Field,
+        hint: []const u8 = "",
+    },
 
-    if (FirstType == ExportType) {
-        return first;
-    } else if (@typeInfo(FirstType) == .enum_literal) {
-        return @field(ExportType, @tagName(first));
-    } else {
-        @compileError("First element must be an ExportType or enum literal");
+    range: struct {
+        field: Field,
+        min: f64,
+        max: f64,
+        step: ?f64 = null,
+        extra_hints: []const []const u8 = &[_][]const u8{},
+    },
+
+    exp_easing: struct {
+        field: Field,
+    },
+
+    @"enum": struct {
+        field: Field,
+        options: []const []const u8,
+    },
+
+    flags: struct {
+        field: Field,
+        options: []const []const u8,
+    },
+
+    flags_2d_physics: struct { field: Field },
+
+    flags_2d_render: struct { field: Field },
+
+    flags_2d_navigation: struct { field: Field },
+
+    flags_3d_physics: struct { field: Field },
+
+    flags_3d_render: struct { field: Field },
+
+    flags_3d_navigation: struct { field: Field },
+
+    file: struct {
+        field: Field,
+        filter: []const u8 = "",
+    },
+
+    dir: struct {
+        field: Field,
+    },
+
+    global_file: struct {
+        field: Field,
+        filter: []const u8 = "",
+    },
+
+    global_dir: struct {
+        field: Field,
+    },
+
+    multiline: struct {
+        field: Field,
+    },
+
+    placeholder: struct {
+        field: Field,
+        placeholder_text: []const u8,
+    },
+
+    color_no_alpha: struct {
+        field: Field,
+    },
+
+    node_path: struct {
+        field: Field,
+        valid_types: []const []const u8 = &[_][]const u8{},
+    },
+
+    storage: struct {
+        field: Field,
+    },
+
+    tool_button: struct {
+        field: Field,
+        label: []const u8,
+        icon: []const u8 = "Callable",
+    },
+
+    custom: struct {
+        field: Field,
+        hint: PropertyHint,
+        hint_string: []const u8 = "",
+        usage: ?PropertyUsageFlags = null,
+    },
+
+    group: struct {
+        name: [:0]const u8,
+        prefix: [:0]const u8 = "",
+    },
+
+    subgroup: struct {
+        name: [:0]const u8,
+        prefix: [:0]const u8 = "",
+    },
+
+    category: struct {
+        name: [:0]const u8,
+    },
+
+    fn isFieldExport(self: Export) bool {
+        return switch (self) {
+            .group, .subgroup, .category => false,
+            else => true,
+        };
     }
-}
 
-fn isFieldExport(comptime exp: ExportType) bool {
-    return switch (exp) {
-        .@"export_group", .@"export_subgroup", .@"export_category" => false,
-        else => true,
-    };
-}
+    fn getFieldName(self: Export) ?[:0]const u8 {
+        return switch (self) {
+            .group, .subgroup, .category => null,
+            inline else => |v| @tagName(v.field),
+        };
+    }
 
-fn getFieldName(comptime entry: anytype) [:0]const u8 {
-    return @tagName(entry[1]);
-}
+    fn getGroupName(self: Export) ?[:0]const u8 {
+        return switch (self) {
+            inline .group, .subgroup, .category => |v| v.name,
+            else => null,
+        };
+    }
 
-fn getGroupName(comptime entry: anytype) [:0]const u8 {
-    return entry[1];
-}
+    fn getPropertyHint(self: Export) struct { hint: PropertyHint, hint_string: [:0]const u8 } {
+        return switch (self) {
+            .property => |v| .{
+                .hint = .property_hint_placeholder_text,
+                .hint_string = v.hint ++ "",
+            },
+            .range => |v| .{
+                .hint = .property_hint_range,
+                .hint_string = std.fmt.comptimePrint("{d},{d}", .{ v.min, v.max }) ++
+                    (if (v.step) |s| std.fmt.comptimePrint(",{d}", .{s}) else "") ++
+                    generateHint(v.extra_hints, true),
+            },
+            .exp_easing => .{ .hint = .property_hint_exp_easing, .hint_string = "" },
+            .@"enum" => |v| .{
+                .hint = .property_hint_enum,
+                .hint_string = generateHint(v.options, false),
+            },
+            .flags => |v| .{
+                .hint = .property_hint_flags,
+                .hint_string = generateHint(v.options, false),
+            },
+            .flags_2d_physics => .{ .hint = .property_hint_layers_2_d_physics, .hint_string = "" },
+            .flags_2d_render => .{ .hint = .property_hint_layers_2_d_render, .hint_string = "" },
+            .flags_2d_navigation => .{ .hint = .property_hint_layers_2_d_navigation, .hint_string = "" },
+            .flags_3d_physics => .{ .hint = .property_hint_layers_3_d_physics, .hint_string = "" },
+            .flags_3d_render => .{ .hint = .property_hint_layers_3_d_render, .hint_string = "" },
+            .flags_3d_navigation => .{ .hint = .property_hint_layers_3_d_navigation, .hint_string = "" },
+            .file => |v| .{
+                .hint = .property_hint_file,
+                .hint_string = v.filter ++ "",
+            },
+            .dir => .{ .hint = .property_hint_dir, .hint_string = "" },
+            .global_file => |v| .{
+                .hint = .property_hint_global_file,
+                .hint_string = v.filter ++ "",
+            },
+            .global_dir => .{ .hint = .property_hint_global_dir, .hint_string = "" },
+            .multiline => .{ .hint = .property_hint_multiline_text, .hint_string = "" },
+            .placeholder => |v| .{
+                .hint = .property_hint_placeholder_text,
+                .hint_string = v.placeholder_text ++ "",
+            },
+            .color_no_alpha => .{ .hint = .property_hint_color_no_alpha, .hint_string = "" },
+            .node_path => |v| .{
+                .hint = .property_hint_node_path_valid_types,
+                .hint_string = generateHint(v.valid_types, false),
+            },
+            .storage => .{ .hint = .property_hint_none, .hint_string = "" },
+            .tool_button => @compileError("tool_button export is not yet implemented"),
+            .custom => |v| .{
+                .hint = v.hint,
+                .hint_string = v.hint_string ++ "",
+            },
+            .group, .subgroup, .category => .{
+                .hint = .property_hint_none,
+                .hint_string = "",
+            },
+        };
+    }
 
-fn buildRangeHintString(comptime entry: anytype) [:0]const u8 {
-    const entry_info = @typeInfo(@TypeOf(entry)).@"struct";
-    const field_count = entry_info.fields.len;
+    fn getPropertyUsage(self: Export) PropertyUsageFlags {
+        return switch (self) {
+            .storage => .{ .property_usage_storage = true },
+            .group => .{ .property_usage_group = true },
+            .subgroup => .{ .property_usage_subgroup = true },
+            .category => .{ .property_usage_category = true },
+            .custom => |v| v.usage orelse PropertyUsageFlags.property_usage_default,
+            else => PropertyUsageFlags.property_usage_default,
+        };
+    }
 
-    if (field_count >= 4) {
-        const min = entry[2];
-        const max = entry[3];
-        if (field_count >= 5) {
-            const step = entry[4];
-            return std.fmt.comptimePrint("{d},{d},{d}", .{ min, max, step });
+    fn generateHint(comptime strings: []const []const u8, comptime prefix_comma: bool) [:0]const u8 {
+        comptime var result: []const u8 = "";
+        inline for (strings, 0..) |s, i| {
+            if (i > 0 or prefix_comma) result = result ++ ",";
+            result = result ++ s;
         }
-        return std.fmt.comptimePrint("{d},{d}", .{ min, max });
+        return result ++ "";
     }
-    return "";
-}
-
-fn buildEnumHintString(comptime entry: anytype) [:0]const u8 {
-    const options = entry[2];
-    const options_info = @typeInfo(@TypeOf(options)).@"struct";
-
-    comptime var result: []const u8 = "";
-    inline for (options_info.fields, 0..) |_, i| {
-        if (i > 0) result = result ++ ",";
-        result = result ++ options[i];
-    }
-    return result ++ "";
-}
-
-fn getPropertyHint(comptime entry: anytype) struct { hint: PropertyHint, hint_string: [:0]const u8 } {
-    const exp = getExportType(entry);
-    const entry_info = @typeInfo(@TypeOf(entry)).@"struct";
-
-    return switch (exp) {
-        .@"export" => .{
-            .hint = .property_hint_none,
-            .hint_string = if (entry_info.fields.len >= 3) entry[2] else "",
-        },
-        .@"export_range" => .{
-            .hint = .property_hint_range,
-            .hint_string = buildRangeHintString(entry),
-        },
-        .@"export_enum" => .{
-            .hint = .property_hint_enum,
-            .hint_string = buildEnumHintString(entry),
-        },
-        .@"export_flags" => .{
-            .hint = .property_hint_flags,
-            .hint_string = buildEnumHintString(entry),
-        },
-        .@"export_flags_2d_physics" => .{ .hint = .property_hint_layers_2_d_physics, .hint_string = "" },
-        .@"export_flags_2d_render" => .{ .hint = .property_hint_layers_2_d_render, .hint_string = "" },
-        .@"export_flags_2d_navigation" => .{ .hint = .property_hint_layers_2_d_navigation, .hint_string = "" },
-        .@"export_flags_3d_physics" => .{ .hint = .property_hint_layers_3_d_physics, .hint_string = "" },
-        .@"export_flags_3d_render" => .{ .hint = .property_hint_layers_3_d_render, .hint_string = "" },
-        .@"export_flags_3d_navigation" => .{ .hint = .property_hint_layers_3_d_navigation, .hint_string = "" },
-        .@"export_file" => .{
-            .hint = .property_hint_file,
-            .hint_string = if (entry_info.fields.len >= 3) entry[2] else "",
-        },
-        .@"export_dir" => .{ .hint = .property_hint_dir, .hint_string = "" },
-        .@"export_global_file" => .{
-            .hint = .property_hint_global_file,
-            .hint_string = if (entry_info.fields.len >= 3) entry[2] else "",
-        },
-        .@"export_global_dir" => .{ .hint = .property_hint_global_dir, .hint_string = "" },
-        .@"export_multiline" => .{ .hint = .property_hint_multiline_text, .hint_string = "" },
-        .@"export_placeholder" => .{
-            .hint = .property_hint_placeholder_text,
-            .hint_string = if (entry_info.fields.len >= 3) entry[2] else "",
-        },
-        .@"export_color_no_alpha" => .{ .hint = .property_hint_color_no_alpha, .hint_string = "" },
-        .@"export_exp_easing" => .{ .hint = .property_hint_exp_easing, .hint_string = "" },
-        .@"export_node_path" => .{
-            .hint = .property_hint_node_path_valid_types,
-            .hint_string = if (entry_info.fields.len >= 3) entry[2] else "",
-        },
-        .@"export_storage" => .{ .hint = .property_hint_none, .hint_string = "" },
-        .@"export_custom" => .{
-            .hint = entry[2],
-            .hint_string = if (entry_info.fields.len >= 4) entry[3] else "",
-        },
-        .@"export_group", .@"export_subgroup", .@"export_category" => .{
-            .hint = .property_hint_none,
-            .hint_string = "",
-        },
-    };
-}
-
-fn getPropertyUsage(comptime entry: anytype) PropertyUsageFlags {
-    const exp = getExportType(entry);
-    const entry_info = @typeInfo(@TypeOf(entry)).@"struct";
-
-    return switch (exp) {
-        .@"export_storage" => .{ .property_usage_storage = true },
-        .@"export_group" => .{ .property_usage_group = true },
-        .@"export_subgroup" => .{ .property_usage_subgroup = true },
-        .@"export_category" => .{ .property_usage_category = true },
-        .@"export_custom" => if (entry_info.fields.len >= 5) entry[4] else PropertyUsageFlags.property_usage_default,
-        else => PropertyUsageFlags.property_usage_default,
-    };
-}
+};
 
 fn validateExports(comptime T: type) void {
     if (!@hasDecl(T, "__exports")) {
@@ -172,11 +226,10 @@ fn validateExports(comptime T: type) void {
     }
 
     inline for (T.__exports) |entry| {
-        const exp = getExportType(entry);
-        if (isFieldExport(exp)) {
-            const field_name = getFieldName(entry);
+        if (entry.isFieldExport()) {
+            const field_name = entry.getFieldName().?;
             if (!@hasField(T, field_name)) {
-                @compileError("Export references non-existent field '." ++ field_name ++ "'");
+                @compileError("Export references non-existent field '" ++ field_name ++ "'");
             }
         }
     }
@@ -207,12 +260,10 @@ pub fn generateGetPropertyListBind(comptime T: type) fn (c.GDExtensionClassInsta
 
             comptime var idx: usize = 0;
             inline for (T.__exports) |entry| {
-                const exp = comptime getExportType(entry);
-
-                if (comptime isFieldExport(exp)) {
-                    const field_name = comptime getFieldName(entry);
-                    const hint_info = comptime getPropertyHint(entry);
-                    const usage = comptime getPropertyUsage(entry);
+                if (comptime entry.isFieldExport()) {
+                    const field_name = comptime entry.getFieldName().?;
+                    const hint_info = comptime entry.getPropertyHint();
+                    const usage = comptime entry.getPropertyUsage();
 
                     const name_ptr = heap.general_allocator.create(StringName) catch @panic("OOM");
                     name_ptr.* = StringName.fromComptimeLatin1(field_name);
@@ -229,8 +280,8 @@ pub fn generateGetPropertyListBind(comptime T: type) fn (c.GDExtensionClassInsta
                         .usage = @bitCast(usage),
                     };
                 } else {
-                    const group_name = comptime getGroupName(entry);
-                    const usage = comptime getPropertyUsage(entry);
+                    const group_name = comptime entry.getGroupName().?;
+                    const usage = comptime entry.getPropertyUsage();
 
                     const name_ptr = heap.general_allocator.create(StringName) catch @panic("OOM");
                     name_ptr.* = StringName.fromComptimeLatin1(group_name);
@@ -268,10 +319,8 @@ pub fn generateSetBind(comptime T: type) fn (c.GDExtensionClassInstancePtr, c.GD
             const prop_value = @as(*Variant, @ptrCast(@alignCast(@constCast(value)))).*;
 
             inline for (T.__exports) |entry| {
-                const exp = comptime getExportType(entry);
-
-                if (comptime isFieldExport(exp)) {
-                    const field_name = comptime getFieldName(entry);
+                if (comptime entry.isFieldExport()) {
+                    const field_name = comptime entry.getFieldName().?;
 
                     var field_str = String.fromLatin1(field_name);
                     defer field_str.deinit();
@@ -301,10 +350,8 @@ pub fn generateGetBind(comptime T: type) fn (c.GDExtensionClassInstancePtr, c.GD
             const prop_name = @as(*StringName, @ptrCast(@constCast(name))).*;
 
             inline for (T.__exports) |entry| {
-                const exp = comptime getExportType(entry);
-
-                if (comptime isFieldExport(exp)) {
-                    const field_name = comptime getFieldName(entry);
+                if (comptime entry.isFieldExport()) {
+                    const field_name = comptime entry.getFieldName().?;
 
                     var field_str = String.fromLatin1(field_name);
                     defer field_str.deinit();
@@ -329,10 +376,8 @@ pub fn generatePropertyCanRevertBind(comptime T: type) fn (c.GDExtensionClassIns
             const prop_name = @as(*StringName, @ptrCast(@constCast(p_name))).*;
 
             inline for (T.__exports) |entry| {
-                const exp = comptime getExportType(entry);
-
-                if (comptime isFieldExport(exp)) {
-                    const field_name = comptime getFieldName(entry);
+                if (comptime entry.isFieldExport()) {
+                    const field_name = comptime entry.getFieldName().?;
 
                     var field_str = String.fromLatin1(field_name);
                     defer field_str.deinit();
@@ -362,10 +407,8 @@ pub fn generatePropertyGetRevertBind(comptime T: type) fn (c.GDExtensionClassIns
             const prop_name = @as(*StringName, @ptrCast(@constCast(p_name))).*;
 
             inline for (T.__exports) |entry| {
-                const exp = comptime getExportType(entry);
-
-                if (comptime isFieldExport(exp)) {
-                    const field_name = comptime getFieldName(entry);
+                if (comptime entry.isFieldExport()) {
+                    const field_name = comptime entry.getFieldName().?;
 
                     var field_str = String.fromLatin1(field_name);
                     defer field_str.deinit();

--- a/gdzig/gdzig.zig
+++ b/gdzig/gdzig.zig
@@ -138,6 +138,7 @@ const std = @import("std");
 pub const c = @import("gdextension");
 
 pub const exports = @import("exports.zig");
+pub const Export = exports.Export;
 pub const builtin = @import("builtin.zig");
 pub const class = @import("class.zig");
 pub const general = @import("general.zig");

--- a/gdzig/object.zig
+++ b/gdzig/object.zig
@@ -203,8 +203,13 @@ pub const PropertyInfo = extern struct {
     }
 
     pub fn deinit(self: *PropertyInfo, allocator: Allocator) void {
-        allocator.free(self.name);
-        allocator.free(self.hint_string);
+        if (self.name) |name| {
+            allocator.destroy(name);
+        }
+        if (self.hint_string) |hint| {
+            hint.deinit();
+            allocator.destroy(hint);
+        }
     }
 };
 

--- a/gdzig/register.zig
+++ b/gdzig/register.zig
@@ -113,7 +113,11 @@ pub fn registerClass(
                 }
             }
             if (p_list) |list| {
-                heap.general_allocator.free(list[0..p_count]);
+                const properties: [*]object.PropertyInfo = @ptrCast(@constCast(list));
+                for (properties[0..p_count]) |*prop| {
+                    prop.deinit(heap.general_allocator);
+                }
+                heap.general_allocator.free(properties[0..p_count]);
             }
         }
 


### PR DESCRIPTION
Implements properties export in a way that does not add complexity to the end user, as the current implementation shown in [`example/src/ExampleNode.zig`](https://github.com/gdzig/gdzig/blob/master/example/src/ExampleNode.zig), and keeps a somewhat familiarity with GDScript.

#### Example

```zig
basic_export: f64 = 100.0,
basic_export_with_hint: f64 = 10.0,

range_int: i64 = 50,
range_float: f64 = 25.0,
range_with_step: i64 = 5,

enum_selection: i64 = 1,

flags_custom: i64 = 0,

// Bitmasks
//   Layer 1 = bit 0 = value 1
//   Layer 2 = bit 1 = value 2
//   Layer 3 = bit 2 = value 4
//   Layer N = bit (N-1) = value 2^(N-1)

flags_2d_physics: i64 = 0,
flags_2d_render: i64 = 0,
flags_2d_navigation: i64 = 0,

flags_3d_physics: i64 = 0,
flags_3d_render: i64 = 0,
flags_3d_navigation: i64 = 0,

custom_hint: f64 = 0.5,

color_rgba: Color = Color.initRGBA(1, 1, 1, 1),
color_no_alpha: Color = Color.initRGBA(0, 0, 0, 1),

exp_easing: f64 = 1.0,

storage_only: i64 = 42,

const PropertyUsageFlags = godot.global.PropertyUsageFlags;

pub const __exports = .{
    .{ .@"export", .basic_export },
    .{ .@"export", .basic_export_with_hint, "Custom hint string" },

    .{ .@"export_group", "Range Tests" },
    .{ .@"export_range", .range_int, 0, 100 },
    .{ .@"export_range", .range_float, 0.0, 100.0, 0.5 },
    .{ .@"export_range", .range_with_step, 1, 10, 1 },

    .{ .@"export_group", "Selection Tests" },
    .{ .@"export_enum", .enum_selection, .{ "Easy", "Normal", "Hard", "Nightmare" } },

    .{ .@"export_flags", .flags_custom, .{ "Visible", "Collidable", "Interactable", "Persistent" } },

    .{ .@"export_group", "2D Layer Masks" },
    .{ .@"export_flags_2d_physics", .flags_2d_physics },
    .{ .@"export_flags_2d_render", .flags_2d_render },
    .{ .@"export_flags_2d_navigation", .flags_2d_navigation },

    .{ .@"export_group", "3D Layer Masks" },
    .{ .@"export_flags_3d_physics", .flags_3d_physics },
    .{ .@"export_flags_3d_render", .flags_3d_render },
    .{ .@"export_flags_3d_navigation", .flags_3d_navigation },

    .{ .@"export_group", "Advanced" },
       
    .{ .@"export_custom", .custom_hint, .property_hint_range, "0.0,1.0,0.01" },

    .{ .@"export_custom", .custom_hint, .property_hint_range, "0.0,1.0,0.01" },

    .{ .@"export_group", "Color Tests" },
    .{ .@"export", .color_rgba },
    .{ .@"export_color_no_alpha", .color_no_alpha },

    .{ .@"export_group", "Animation" },
    .{ .@"export_exp_easing", .exp_easing },

    .{ .@"export_storage", .storage_only },

    .{ .@"export_category", "Debug Info" },
};

```

#### Implements

- [x] @export
- [x] @export_group
- [x] @export_subgroup
- [x] @export_category
- [x] @export_file
- [x] @export_dir
- [x] @export_global_file
- [x] @export_global_dir
- [x] @export_multiline
- [x] @export_range
- [x] @export_exp_easing
- [x] @export_color_no_alpha
- [x] @export_node_path
- [x] @export_flags
- [x] @export_flags_2d_physics
- [x] @export_flags_2d_render
- [x] @export_flags_2d_navigation
- [x] @export_flags_3d_physics
- [x] @export_flags_3d_render
- [x] @export_flags_3d_navigation
- [x] @export_enum
- [x] @export_storage
- [x] @export_custom 
- [ ] @export_tool_button
