### PR TITLE
fix(build): fix caching for bindgen step

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1,5 +1,4 @@
 pub fn build(b: *Build) !void {
-    // Options
     const opt: Options = .{
         .target = b.standardTargetOptions(.{}),
         .optimize = b.standardOptimizeOption(.{}),
@@ -239,7 +238,8 @@ fn buildGenerated(
     });
 
     const run = b.addRunArtifact(bindgen);
-    run.stdio = .inherit;
+    run.expectExitCode(0);
+
     run.addDirectoryArg(headers);
     run.addDirectoryArg(input);
     const output = run.addOutputDirectoryArg("generated");


### PR DESCRIPTION
From the [official documentation](https://ziglang.org/documentation/master/std/#std.Build.Step.Run.StdIo)

> Causes the Run step to be considered to have side-effects, and therefore always execute when it appears in the build graph. It also means that this step will obtain a global lock to prevent other steps from running in the meantime. The step will fail if the subprocess crashes or returns a non-zero exit code.

`run.stdio = .inherit;` disables caching, forcing the step to run on every build.

Instead, `expectExitCode` should be used, which acts similarly to `run.stdio = .check`:

> Causes the Run step to be considered to not have side-effects. The process will be re-executed if any of the input dependencies are modified. The exit code and standard I/O streams will be checked for certain conditions, and the step will succeed or fail based on these conditions. Note that an explicit check for exit code 0 needs to be added to this list if such a check is desirable.

This still outputs bindgen's stdout/stderr which originally was the intended use of `.inherit`
