### PR TITLE
flatten build.zig

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1,7 +1,3 @@
-const std = @import("std");
-const Build = std.Build;
-const Step = std.Build.Step;
-
 pub fn build(b: *Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
@@ -204,3 +200,7 @@ pub fn build(b: *Build) void {
         .install_subdir = "docs",
     });
 }
+
+const std = @import("std");
+const Build = std.Build;
+const Step = std.Build.Step;


### PR DESCRIPTION
I don't know what I was on when I did this before, but I've learned to just keep build.zig flat and simple these days.

it will hopefully be easier to identify the use case #148 was attempting to solve for with the simpler build.zig