### PR TITLE
rewrite class registration

### DIFF
--- a/.zed/debug.json
+++ b/.zed/debug.json
@@ -3,7 +3,7 @@
     "label": "Debug Example",
     "adapter": "CodeLLDB",
     "request": "launch",
-    "program": "godot",
+    "program": "/nix/store/bhmlywmx3g9vng9s7sla3hhalvjz4cdd-godot-4.4.1-stable/bin/godot",
     "args": [],
     "build": "Build Example",
     "cwd": "${ZED_WORKTREE_ROOT}/example/project"

--- a/example/src/ExampleNode.zig
+++ b/example/src/ExampleNode.zig
@@ -52,7 +52,7 @@ pub fn _process(self: *ExampleNode, _: f64) void {
 
 fn clearScene(self: *ExampleNode) void {
     if (self.example_node) |n| {
-        godot.object.destroy(n);
+        godot.destroy(n);
         //n.queue_free(); //ok
     }
 }
@@ -69,7 +69,7 @@ pub fn onItemFocused(self: *ExampleNode, idx: i64) void {
     self.clearScene();
     switch (idx) {
         inline 0...Examples.len - 1 => |i| {
-            const n = godot.object.create(Examples[i].T) catch unreachable;
+            const n = godot.create(Examples[i].T) catch unreachable;
             self.example_node = .upcast(n);
             self.panel.addChild(self.example_node.?, .{});
             self.panel.grabFocus();
@@ -79,12 +79,8 @@ pub fn onItemFocused(self: *ExampleNode, idx: i64) void {
 }
 
 pub fn _enterTree(self: *ExampleNode) void {
-    inline for (Examples) |E| {
-        godot.registerClass(E.T, .{});
-    }
-
     // test T -> variant -> T
-    const obj: *ExampleNode = godot.object.create(ExampleNode) catch unreachable;
+    const obj: *ExampleNode = godot.create(ExampleNode) catch unreachable;
     const variant: Variant = Variant.init(obj);
     const result = variant.as(*ExampleNode).?;
     std.debug.print("Result: {}\n", .{result.fps_counter.getPosition()});
@@ -134,7 +130,7 @@ pub fn _exitTree(self: *ExampleNode) void {
     _ = self;
 }
 
-pub fn _notification(self: *ExampleNode, what: i32) void {
+pub fn _notification(self: *ExampleNode, what: i32, _: bool) void {
     if (what == Node.NOTIFICATION_WM_CLOSE_REQUEST) {
         if (!Engine.isEditorHint()) {
             self.base.getTree().?.quit(.{});
@@ -142,14 +138,12 @@ pub fn _notification(self: *ExampleNode, what: i32) void {
     }
 }
 
-pub fn _getPropertyList(_: *ExampleNode, p: *godot.object.PropertyBuilder) !void {
-    try p.append(ExampleNode, property1_name, .{});
-    try p.append(ExampleNode, property2_name, .{
-        .hint_string = "hint2",
-    });
+pub fn _getPropertyList(_: *ExampleNode) std.mem.Allocator.Error![]const godot.classdb.PropertyInfo {
+    // For now, return empty list - property list needs proper allocator support
+    return &.{};
 }
 
-pub fn _propertyCanRevert(_: *ExampleNode, name: StringName) bool {
+pub fn _propertyCanRevert(_: *ExampleNode, name: *const StringName) bool {
     var prop1 = String.fromLatin1(property1_name);
     defer prop1.deinit();
 
@@ -165,7 +159,7 @@ pub fn _propertyCanRevert(_: *ExampleNode, name: StringName) bool {
     return false;
 }
 
-pub fn _propertyGetRevert(_: *ExampleNode, name: StringName, value: *Variant) bool {
+pub fn _propertyGetRevert(_: *ExampleNode, name: *const StringName) godot.PropertyError!Variant {
     var prop1 = String.fromLatin1(property1_name);
     defer prop1.deinit();
 
@@ -173,17 +167,15 @@ pub fn _propertyGetRevert(_: *ExampleNode, name: StringName, value: *Variant) bo
     defer prop2.deinit();
 
     if (name.casecmpTo(prop1) == 0) {
-        value.* = Variant.init(Vector3.initXYZ(42, 42, 42));
-        return true;
+        return Variant.init(Vector3.initXYZ(42, 42, 42));
     } else if (name.casecmpTo(prop2) == 0) {
-        value.* = Variant.init(Vector3.initXYZ(24, 24, 24));
-        return true;
+        return Variant.init(Vector3.initXYZ(24, 24, 24));
     }
 
-    return false;
+    return error.InvalidKey;
 }
 
-pub fn _set(self: *ExampleNode, name: StringName, value: Variant) bool {
+pub fn _set(self: *ExampleNode, name: *const StringName, value: *const Variant) godot.PropertyError!void {
     var prop1 = String.fromLatin1(property1_name);
     defer prop1.deinit();
 
@@ -192,16 +184,16 @@ pub fn _set(self: *ExampleNode, name: StringName, value: Variant) bool {
 
     if (name.casecmpTo(prop1) == 0) {
         self.property1 = value.as(Vector3).?;
-        return true;
+        return;
     } else if (name.casecmpTo(prop2) == 0) {
         self.property2 = value.as(Vector3).?;
-        return true;
+        return;
     }
 
-    return false;
+    return error.InvalidKey;
 }
 
-pub fn _get(self: *ExampleNode, name: StringName, value: *Variant) bool {
+pub fn _get(self: *ExampleNode, name: *const StringName) godot.PropertyError!Variant {
     var prop1 = String.fromLatin1(property1_name);
     defer prop1.deinit();
 
@@ -209,24 +201,22 @@ pub fn _get(self: *ExampleNode, name: StringName, value: *Variant) bool {
     defer prop2.deinit();
 
     if (name.casecmpTo(prop1) == 0) {
-        value.* = Variant.init(self.property1);
-        return true;
+        return Variant.init(self.property1);
     } else if (name.casecmpTo(prop2) == 0) {
-        value.* = Variant.init(self.property2);
-        return true;
+        return Variant.init(self.property2);
     }
 
-    return false;
+    return error.InvalidKey;
 }
 
 pub fn _toString(_: *ExampleNode) ?String {
     return String.fromLatin1("ExampleNode");
 }
 
-pub fn _bindMethods() void {
-    godot.registerMethod(ExampleNode, "onTimeout");
-    godot.registerMethod(ExampleNode, "onResized");
-    godot.registerMethod(ExampleNode, "onItemFocused");
+pub fn _register() void {
+    godot.registerMethod(ExampleNode, .onTimeout);
+    godot.registerMethod(ExampleNode, .onResized);
+    godot.registerMethod(ExampleNode, .onItemFocused);
 }
 
 const std = @import("std");
@@ -236,6 +226,7 @@ const Engine = godot.class.Engine;
 const HSplitContainer = godot.class.HSplitContainer;
 const ItemList = godot.class.ItemList;
 const Label = godot.class.Label;
+const Object = godot.class.Object;
 const Node = godot.class.Node;
 const PanelContainer = godot.class.PanelContainer;
 const String = godot.builtin.String;

--- a/example/src/GuiNode.zig
+++ b/example/src/GuiNode.zig
@@ -1,9 +1,9 @@
-const Self = @This();
+const GuiNode = @This();
 
 base: *Control,
 sprite: *Sprite2D = undefined,
 
-pub fn _enterTree(self: *Self) void {
+pub fn _enterTree(self: *GuiNode) void {
     if (Engine.isEditorHint()) return;
 
     var normal_btn = Button.init();
@@ -33,23 +33,23 @@ pub fn _enterTree(self: *Self) void {
     self.base.addChild(.upcast(self.sprite), .{});
 }
 
-pub fn _exitTree(self: *Self) void {
+pub fn _exitTree(self: *GuiNode) void {
     _ = self;
 }
 
-pub fn onPressed(self: *Self) void {
+pub fn onPressed(self: *GuiNode) void {
     _ = self;
     std.debug.print("onPressed \n", .{});
 }
 
-pub fn onToggled(self: *Self, toggled_on: bool) void {
+pub fn onToggled(self: *GuiNode, toggled_on: bool) void {
     _ = self;
     std.debug.print("on_toggled {any}\n", .{toggled_on});
 }
 
 pub fn _bindMethods() void {
-    godot.registerMethod(@This(), "onPressed");
-    godot.registerMethod(@This(), "onToggled");
+    godot.registerMethod(GuiNode, .onPressed);
+    godot.registerMethod(GuiNode, .onToggled);
 }
 
 const std = @import("std");

--- a/example/src/SignalNode.zig
+++ b/example/src/SignalNode.zig
@@ -10,13 +10,13 @@ pub const Signal1 = struct {
 pub const Signal2 = struct {};
 pub const Signal3 = struct {};
 
-pub fn _bindMethods() void {
-    godot.registerMethod(Self, "onSignal1");
-    godot.registerMethod(Self, "onSignal2");
-    godot.registerMethod(Self, "onSignal3");
-    godot.registerMethod(Self, "emitSignal1");
-    godot.registerMethod(Self, "emitSignal2");
-    godot.registerMethod(Self, "emitSignal3");
+pub fn _register() void {
+    godot.registerMethod(Self, .onSignal1);
+    godot.registerMethod(Self, .onSignal2);
+    godot.registerMethod(Self, .onSignal3);
+    godot.registerMethod(Self, .emitSignal1);
+    godot.registerMethod(Self, .emitSignal2);
+    godot.registerMethod(Self, .emitSignal3);
     godot.registerSignal(Self, Signal1);
     godot.registerSignal(Self, Signal2);
     godot.registerSignal(Self, Signal3);

--- a/example/src/SpriteNode.zig
+++ b/example/src/SpriteNode.zig
@@ -1,8 +1,19 @@
 const Self = @This();
 
 base: *Control,
+allocator: Allocator,
 rng: std.Random = undefined,
 sprites: ArrayList(Sprite) = .empty,
+
+pub fn init(base: *Control, allocator: Allocator) Self {
+    var prng = std.Random.DefaultPrng.init(@intCast(std.time.timestamp()));
+
+    return .{
+        .base = base,
+        .allocator = allocator,
+        .rng = prng.random(),
+    };
+}
 
 const Sprite = struct {
     pos: Vector2,
@@ -24,9 +35,6 @@ pub fn randfRange(self: Self, comptime T: type, min: T, max: T) T {
 
 pub fn _ready(self: *Self) void {
     if (Engine.isEditorHint()) return;
-
-    var prng = std.Random.DefaultPrng.init(@intCast(std.time.timestamp()));
-    self.rng = prng.random();
 
     var logo_path: String = .fromLatin1("res://textures/logo.png");
     defer logo_path.deinit();
@@ -50,14 +58,14 @@ pub fn _ready(self: *Self) void {
         spr.gd_sprite.setScale(spr.scale);
         spr.size = spr.gd_sprite.getRect().size;
         self.base.addChild(.upcast(spr.gd_sprite), .{});
-        self.sprites.append(godot.heap.general_allocator, spr) catch |err| {
+        self.sprites.append(self.allocator, spr) catch |err| {
             std.log.err("Failed to append sprite: {}", .{err});
         };
     }
 }
 
 pub fn _exitTree(self: *Self) void {
-    self.sprites.deinit(godot.heap.general_allocator);
+    self.sprites.deinit(self.allocator);
 }
 
 pub fn _physicsProcess(self: *Self, delta: f64) void {
@@ -83,6 +91,7 @@ pub fn _physicsProcess(self: *Self, delta: f64) void {
 }
 
 const std = @import("std");
+const Allocator = std.mem.Allocator;
 const ArrayList = std.ArrayList;
 
 const godot = @import("gdzig");

--- a/example/src/example.zig
+++ b/example/src/example.zig
@@ -1,14 +1,19 @@
-var gpa: std.heap.DebugAllocator(.{}) = .init;
-
 comptime {
     godot.entrypoint("my_extension_init", .{ .init = &init, .deinit = &deinit });
 }
+
+var gpa: std.heap.DebugAllocator(.{}) = .{
+    .backing_allocator = godot.heap.godot_allocator.allocator(),
+};
 
 fn init(level: godot.InitializationLevel) void {
     std.debug.print("[{s}] init\n", .{@tagName(level)});
 
     if (level == .scene) {
-        godot.registerClass(@import("ExampleNode.zig"), .{});
+        godot.registerClass(gpa.allocator(), @import("ExampleNode.zig"), .{});
+        godot.registerClass(gpa.allocator(), @import("SpriteNode.zig"), .{});
+        godot.registerClass(gpa.allocator(), @import("GuiNode.zig"), .{});
+        godot.registerClass(gpa.allocator(), @import("SignalNode.zig"), .{});
     }
 }
 

--- a/gdzig/classdb.zig
+++ b/gdzig/classdb.zig
@@ -285,7 +285,7 @@ fn wrapSet(comptime T: type, comptime callback: Set(T)) Child(c.GDExtensionClass
         fn wrapped(p_instance: c.GDExtensionClassInstancePtr, p_name: c.GDExtensionConstStringNamePtr, p_value: c.GDExtensionConstVariantPtr) callconv(.c) c.GDExtensionBool {
             const instance = @as(*T, @ptrCast(@alignCast(p_instance)));
             const name = @as(*const StringName, @ptrCast(p_name));
-            const value = @as(*const Variant, @ptrCast(p_value));
+            const value = @as(*const Variant, @ptrCast(@alignCast(p_value)));
             callback(instance, name, value) catch return 0;
             return 1;
         }
@@ -314,13 +314,13 @@ pub fn GetPropertyList(comptime T: type) type {
 
 fn wrapGetPropertyList(comptime T: type, comptime callback: GetPropertyList(T)) Child(c.GDExtensionClassGetPropertyList) {
     return struct {
-        fn wrapped(p_instance: c.GDExtensionClassInstancePtr, r_count: *u32) callconv(.c) ?*const c.GDExtensionPropertyInfo {
+        fn wrapped(p_instance: c.GDExtensionClassInstancePtr, r_count: [*c]u32) callconv(.c) [*c]const c.GDExtensionPropertyInfo {
             const instance = @as(*T, @ptrCast(@alignCast(p_instance)));
             const list = callback(instance) catch {
-                r_count.* = 0;
+                if (r_count) |cnt| cnt.* = 0;
                 return null;
             };
-            r_count.* = @intCast(list.len);
+            if (r_count) |cnt| cnt.* = @intCast(list.len);
             if (list.len == 0) return null;
             return @ptrCast(list.ptr);
         }
@@ -438,14 +438,14 @@ pub fn ToString(comptime T: type) type {
 
 fn wrapToString(comptime T: type, comptime callback: ToString(T)) Child(c.GDExtensionClassToString) {
     return struct {
-        fn wrapped(p_instance: c.GDExtensionClassInstancePtr, r_is_valid: *c.GDExtensionBool, p_out: c.GDExtensionStringPtr) callconv(.c) void {
+        fn wrapped(p_instance: c.GDExtensionClassInstancePtr, r_is_valid: [*c]c.GDExtensionBool, p_out: c.GDExtensionStringPtr) callconv(.c) void {
             const instance = @as(*T, @ptrCast(@alignCast(p_instance)));
             const out = @as(*String, @ptrCast(@alignCast(p_out)));
             out.* = callback(instance) orelse {
-                r_is_valid.* = 0;
+                if (r_is_valid) |v| v.* = 0;
                 return;
             };
-            r_is_valid.* = 1;
+            if (r_is_valid) |v| v.* = 1;
         }
     }.wrapped;
 }
@@ -513,22 +513,22 @@ fn wrapCallVirtual(comptime T: type, comptime callback: CallVirtual(T)) Child(c.
 
 pub fn GetVirtual(comptime T: type, comptime ClassUserdata: type) type {
     return if (ClassUserdata != void)
-        fn (userdata: *ClassUserdata, name: *const StringName) ?CallVirtual(T)
+        fn (userdata: *ClassUserdata, name: *const StringName) ?*const CallVirtual(T)
     else
-        fn (name: *const StringName) ?CallVirtual(T);
+        fn (name: *const StringName) ?*const CallVirtual(T);
 }
 
 fn wrapGetVirtual(comptime T: type, comptime ClassUserdata: type, comptime callback: GetVirtual(T, ClassUserdata)) Child(c.GDExtensionClassGetVirtual) {
     return struct {
         fn wrapped(p_class_userdata: ?*anyopaque, p_name: c.GDExtensionConstStringNamePtr) callconv(.c) c.GDExtensionClassCallVirtual {
             const name = @as(*const StringName, @ptrCast(p_name));
-            const virtual: ?CallVirtual(T) = if (ClassUserdata != void) blk: {
+            const virtual: ?*const CallVirtual(T) = if (ClassUserdata != void) blk: {
                 const userdata = @as(*ClassUserdata, @ptrCast(@alignCast(p_class_userdata)));
                 break :blk callback(userdata, name);
             } else callback(name);
 
             if (virtual) |v| {
-                return wrapCallVirtual(T, v);
+                return @ptrCast(v);
             }
             return null;
         }
@@ -537,22 +537,22 @@ fn wrapGetVirtual(comptime T: type, comptime ClassUserdata: type, comptime callb
 
 pub fn GetVirtual2(comptime T: type, comptime ClassUserdata: type) type {
     return if (ClassUserdata != void)
-        fn (userdata: *ClassUserdata, name: *const StringName, hash: u32) ?CallVirtual(T)
+        fn (userdata: *ClassUserdata, name: *const StringName, hash: u32) ?*const CallVirtual(T)
     else
-        fn (name: *const StringName, hash: u32) ?CallVirtual(T);
+        fn (name: *const StringName, hash: u32) ?*const CallVirtual(T);
 }
 
 fn wrapGetVirtual2(comptime T: type, comptime ClassUserdata: type, comptime callback: GetVirtual2(T, ClassUserdata)) Child(c.GDExtensionClassGetVirtual2) {
     return struct {
         fn wrapped(p_class_userdata: ?*anyopaque, p_name: c.GDExtensionConstStringNamePtr, p_hash: u32) callconv(.c) c.GDExtensionClassCallVirtual {
             const name = @as(*const StringName, @ptrCast(p_name));
-            const virtual: ?CallVirtual(T) = if (ClassUserdata != void) blk: {
+            const virtual: ?*const CallVirtual(T) = if (ClassUserdata != void) blk: {
                 const userdata = @as(*ClassUserdata, @ptrCast(@alignCast(p_class_userdata)));
                 break :blk callback(userdata, name, p_hash);
             } else callback(name, p_hash);
 
             if (virtual) |v| {
-                return wrapCallVirtual(T, v);
+                return @ptrCast(v);
             }
             return null;
         }
@@ -631,9 +631,9 @@ pub fn MethodInfo(comptime Userdata: type) type {
     return if (Userdata != void)
         struct {
             userdata: *Userdata,
-            name: *const StringName,
+            name: *StringName,
             flags: MethodFlags = .{},
-            return_value_info: ?*const PropertyInfo = null,
+            return_value_info: ?*PropertyInfo = null,
             return_value_metadata: MethodArgumentMetadata = .none,
             argument_info: []const PropertyInfo = &.{},
             argument_metadata: []const MethodArgumentMetadata = &.{},
@@ -641,9 +641,9 @@ pub fn MethodInfo(comptime Userdata: type) type {
         }
     else
         struct {
-            name: *const StringName,
+            name: *StringName,
             flags: MethodFlags = .{},
-            return_value_info: ?*const PropertyInfo = null,
+            return_value_info: ?*PropertyInfo = null,
             return_value_metadata: MethodArgumentMetadata = .none,
             argument_info: []const PropertyInfo = &.{},
             argument_metadata: []const MethodArgumentMetadata = &.{},
@@ -683,7 +683,7 @@ pub fn Call(comptime T: type, comptime Userdata: type) type {
 
 fn wrapCall(comptime T: type, comptime Userdata: type, comptime callback: Call(T, Userdata)) Child(c.GDExtensionClassMethodCall) {
     return struct {
-        fn wrapped(method_userdata: ?*anyopaque, p_instance: c.GDExtensionClassInstancePtr, p_args: [*c]const c.GDExtensionConstVariantPtr, p_argument_count: c.GDExtensionInt, r_return: c.GDExtensionVariantPtr, r_error: *c.GDExtensionCallError) callconv(.c) void {
+        fn wrapped(method_userdata: ?*anyopaque, p_instance: c.GDExtensionClassInstancePtr, p_args: [*c]const c.GDExtensionConstVariantPtr, p_argument_count: c.GDExtensionInt, r_return: c.GDExtensionVariantPtr, r_error: [*c]c.GDExtensionCallError) callconv(.c) void {
             const instance = @as(*T, @ptrCast(@alignCast(p_instance)));
             const args = @as([*]const *const Variant, @ptrCast(p_args))[0..@intCast(p_argument_count)];
             const ret = @as(*Variant, @ptrCast(@alignCast(r_return)));
@@ -691,16 +691,16 @@ fn wrapCall(comptime T: type, comptime Userdata: type, comptime callback: Call(T
             if (Userdata != void) {
                 const userdata = @as(*Userdata, @ptrCast(@alignCast(method_userdata)));
                 ret.* = callback(userdata, instance, args) catch |err| {
-                    r_error.* = @bitCast(CallResult.fromError(err));
+                    if (r_error) |e| e.* = @bitCast(CallResult.fromError(err));
                     return;
                 };
             } else {
                 ret.* = callback(instance, args) catch |err| {
-                    r_error.* = @bitCast(CallResult.fromError(err));
+                    if (r_error) |e| e.* = @bitCast(CallResult.fromError(err));
                     return;
                 };
             }
-            r_error.*.@"error" = c.GDEXTENSION_CALL_OK;
+            if (r_error) |e| e.*.@"error" = c.GDEXTENSION_CALL_OK;
         }
     }.wrapped;
 }
@@ -778,11 +778,11 @@ pub const CallResult = extern struct {
 
 pub const PropertyInfo = extern struct {
     type: Variant.Tag,
-    name: *const StringName,
-    class_name: *const StringName,
-    hint: PropertyHint,
-    hint_string: *const String,
-    usage: PropertyUsageFlags,
+    name: ?*const StringName = null,
+    class_name: ?*const StringName = null,
+    hint: PropertyHint = .property_hint_none,
+    hint_string: ?*const String = null,
+    usage: PropertyUsageFlags = .property_usage_none,
 };
 
 //
@@ -1002,10 +1002,10 @@ pub inline fn registerMethod(
             .return_value_info = @ptrCast(info.return_value_info),
             .return_value_metadata = @intFromEnum(info.return_value_metadata),
             .argument_count = @intCast(info.argument_info.len),
-            .arguments_info = @ptrCast(info.argument_info.ptr),
-            .arguments_metadata = @ptrCast(info.argument_metadata.ptr),
+            .arguments_info = @ptrCast(@constCast(info.argument_info.ptr)),
+            .arguments_metadata = @ptrCast(@constCast(info.argument_metadata.ptr)),
             .default_argument_count = @intCast(info.default_arguments.len),
-            .default_arguments = @ptrCast(info.default_arguments.ptr),
+            .default_arguments = @ptrCast(@constCast(info.default_arguments.ptr)),
         },
     );
 }

--- a/gdzig/gdzig.zig
+++ b/gdzig/gdzig.zig
@@ -32,6 +32,8 @@ pub const InitializationLevel = enum(c_int) {
     editor = 3,
 };
 
+pub var version: GodotVersion = undefined;
+
 pub const GodotVersion = extern struct {
     major: u32,
     minor: u32,
@@ -146,6 +148,7 @@ pub fn entrypointWithUserdata(
         ) callconv(.c) c.GDExtensionBool {
             raw = .init(p_get_proc_address.?, p_library.?);
             interface = &raw;
+            version = .current();
             r_initialization.*.userdata = if (Userdata != void) opt.userdata() else null;
             r_initialization.*.initialize = @ptrCast(&init);
             r_initialization.*.deinitialize = @ptrCast(&deinit);
@@ -169,10 +172,6 @@ pub fn entrypointWithUserdata(
                     deinit_cb(@enumFromInt(p_level));
                 } else {
                     deinit_cb(@ptrCast(userdata.?), @enumFromInt(p_level));
-                }
-                if (p_level == c.GDEXTENSION_INITIALIZATION_CORE) {
-                    // TODO: remove
-                    register.deinit();
                 }
             }
         }
@@ -207,6 +206,26 @@ pub fn typeName(comptime T: type) *builtin.StringName {
 
 pub fn signalName(comptime S: type) builtin.StringName {
     return .fromComptimeLatin1(meta.signalName(S));
+}
+
+pub fn create(comptime T: type) !*T {
+    const class_name = meta.typeName(T);
+
+    if (version.gte(.@"4.4")) {
+        return if (raw.classdbConstructObject2(class_name)) |any|
+            @ptrCast(@alignCast(any))
+        else
+            return error.OutOfMemory;
+    } else {
+        return if (raw.classdbConstructObject(class_name)) |any|
+            @ptrCast(@alignCast(any))
+        else
+            return error.OutOfMemory;
+    }
+}
+
+pub fn destroy(obj: anytype) void {
+    raw.objectDestroy(@ptrCast(obj));
 }
 
 const std = @import("std");

--- a/gdzig/heap.zig
+++ b/gdzig/heap.zig
@@ -1,9 +1,5 @@
 /// Global instance of the Godot allocator
 pub var godot_allocator: GodotAllocator = .init;
-pub var debug_allocator: std.heap.DebugAllocator(.{}) = .{
-    .backing_allocator = godot_allocator.allocator(),
-};
-pub var general_allocator = debug_allocator.allocator();
 
 /// Godot memory allocator that implements the Zig Allocator interface.
 /// This allocator uses Godot's memory management functions internally.

--- a/gdzig/object.zig
+++ b/gdzig/object.zig
@@ -176,8 +176,8 @@ fn assertCanInitialize(comptime T: type) void {
 
 pub fn VTable(comptime T: type, comptime method_names: anytype) type {
     return struct {
-        const map: std.StaticStringMap(CallVirtual(T)) = .initComptime(blk: {
-            var kvs: [method_names.len]struct { []const u8, CallVirtual(T) } = undefined;
+        const map: std.StaticStringMap(*const CallVirtual(T)) = .initComptime(blk: {
+            var kvs: [method_names.len]struct { []const u8, *const CallVirtual(T) } = undefined;
             for (method_names, 0..) |name, i| {
                 kvs[i] = .{ name, makeWrapper(name) };
             }
@@ -188,7 +188,7 @@ pub fn VTable(comptime T: type, comptime method_names: anytype) type {
             return map.has(name);
         }
 
-        pub fn get(name: []const u8) ?CallVirtual(T) {
+        pub fn get(name: []const u8) ?*const CallVirtual(T) {
             return map.get(name);
         }
 
@@ -196,12 +196,30 @@ pub fn VTable(comptime T: type, comptime method_names: anytype) type {
             return VTable(Derived, combineNames(override_names));
         }
 
-        fn combineNames(comptime override_names: anytype) [][]const u8 {
-            var combined_names: [method_names.len + override_names.len][]const u8 = undefined;
-            var i = 0;
-            @memcpy(combined_names[0..method_names.len], method_names);
-            outer: inline for (override_names) |override_name| {
-                inline for (method_names) |method_name| {
+        fn countNew(comptime override_names: anytype) usize {
+            @setEvalBranchQuota(10000);
+            var count: usize = 0;
+            outer: for (override_names) |override_name| {
+                for (method_names) |method_name| {
+                    if (std.mem.eql(u8, override_name, method_name)) {
+                        continue :outer;
+                    }
+                }
+                count += 1;
+            }
+            return count;
+        }
+
+        fn combineNames(comptime override_names: anytype) [method_names.len + countNew(override_names)][]const u8 {
+            @setEvalBranchQuota(10000);
+            var combined_names: [method_names.len + countNew(override_names)][]const u8 = undefined;
+            for (0..method_names.len) |i| {
+                combined_names[i] = method_names[i];
+            }
+
+            var i: usize = 0;
+            outer: for (override_names) |override_name| {
+                for (method_names) |method_name| {
                     if (std.mem.eql(u8, override_name, method_name)) {
                         continue :outer;
                     }
@@ -209,10 +227,12 @@ pub fn VTable(comptime T: type, comptime method_names: anytype) type {
                 combined_names[method_names.len + i] = override_name;
                 i += 1;
             }
-            return combined_names[0 .. method_names.len + i];
+
+            return combined_names;
         }
 
-        fn makeWrapper(comptime method_name: []const u8) CallVirtual(T) {
+        fn makeWrapper(comptime method_name: []const u8) *const CallVirtual(T) {
+            @setEvalBranchQuota(10000);
             inline for (selfAndAncestorsOf(T)) |Owner| {
                 if (@hasDecl(Owner, method_name)) {
                     const method = @field(Owner, method_name);
@@ -220,16 +240,18 @@ pub fn VTable(comptime T: type, comptime method_names: anytype) type {
                     const fn_info = @typeInfo(FnType).@"fn";
                     const ReturnType = fn_info.return_type orelse void;
 
-                    return struct {
+                    return &struct {
                         fn call(p_instance: *T, p_args: [*]const *const anyopaque, p_ret: *anyopaque) void {
                             const instance: *Owner = if (Owner == T) p_instance else upcast(*Owner, p_instance);
 
                             var args: std.meta.ArgsTuple(FnType) = undefined;
-                            args[0] = instance;
+                            if (fn_info.params.len > 0) {
+                                args[0] = instance;
 
-                            inline for (1..fn_info.params.len) |j| {
-                                const Arg = fn_info.params[j].type.?;
-                                args[j] = @as(*const Arg, @ptrCast(@alignCast(p_args[j - 1]))).*;
+                                inline for (1..fn_info.params.len) |j| {
+                                    const Arg = fn_info.params[j].type.?;
+                                    args[j] = @as(*const Arg, @ptrCast(@alignCast(p_args[j - 1]))).*;
+                                }
                             }
 
                             if (ReturnType == void) {

--- a/gdzig/register.zig
+++ b/gdzig/register.zig
@@ -22,7 +22,7 @@ pub fn registerClass(
     const version = GodotVersion.current();
 
     if (version.gte(.@"4.4")) {
-        classdb.registerClass4(T, *Allocator, void, &class_name, &base_name, .{
+        classdb.registerClass4(T, Allocator, void, &class_name, &base_name, .{
             .userdata = &Static.class_allocator,
             .is_virtual = opt.virtual,
             .is_abstract = opt.abstract,
@@ -30,7 +30,7 @@ pub fn registerClass(
             .is_runtime = opt.runtime,
         }, callbacks.v4);
     } else if (version.gte(.@"4.3")) {
-        classdb.registerClass3(T, *Allocator, void, &class_name, &base_name, .{
+        classdb.registerClass3(T, Allocator, void, &class_name, &base_name, .{
             .userdata = &Static.class_allocator,
             .is_virtual = opt.virtual,
             .is_abstract = opt.abstract,
@@ -38,14 +38,14 @@ pub fn registerClass(
             .is_runtime = opt.runtime,
         }, callbacks.v3);
     } else if (version.gte(.@"4.2")) {
-        classdb.registerClass2(T, *Allocator, void, &class_name, &base_name, .{
+        classdb.registerClass2(T, Allocator, void, &class_name, &base_name, .{
             .userdata = &Static.class_allocator,
             .is_virtual = opt.virtual,
             .is_abstract = opt.abstract,
             .is_exposed = opt.exposed,
         }, callbacks.v2);
     } else if (version.gte(.@"4.1")) {
-        classdb.registerClass1(T, *Allocator, &class_name, &base_name, .{
+        classdb.registerClass1(T, Allocator, &class_name, &base_name, .{
             .userdata = &Static.class_allocator,
             .is_virtual = opt.virtual,
             .is_abstract = opt.abstract,
@@ -60,10 +60,10 @@ pub fn registerClass(
 }
 
 fn makeClassCallbacks(comptime T: type) struct {
-    v1: classdb.ClassCallbacks1(T, *Allocator),
-    v2: classdb.ClassCallbacks2(T, *Allocator, void),
-    v3: classdb.ClassCallbacks3(T, *Allocator, void),
-    v4: classdb.ClassCallbacks4(T, *Allocator, void),
+    v1: classdb.ClassCallbacks1(T, Allocator),
+    v2: classdb.ClassCallbacks2(T, Allocator, void),
+    v3: classdb.ClassCallbacks3(T, Allocator, void),
+    v4: classdb.ClassCallbacks4(T, Allocator, void),
 } {
     // Assert that we can initialize the user type
     comptime {
@@ -133,17 +133,18 @@ fn makeClassCallbacks(comptime T: type) struct {
             T._notification(instance, what, false);
         }
 
-        fn getVirtual(name: *const StringName) ?classdb.CallVirtual(T) {
+        fn getVirtual(allocator: *Allocator, name: *const StringName) ?*const classdb.CallVirtual(T) {
+            _ = allocator;
             const Base = object.BaseOf(T);
             const UserVTable = Base.VTable.extend(T, virtualMethodNames(T));
             var buf: [256]u8 = undefined;
-            const name_str = name.toUtf8(&buf);
+            const name_str = godot.string.stringNameToAscii(name.*, buf[0..]);
             return UserVTable.get(name_str);
         }
 
-        fn getVirtual2(name: *const StringName, hash: u32) ?classdb.CallVirtual(T) {
+        fn getVirtual2(allocator: *Allocator, name: *const StringName, hash: u32) ?*const classdb.CallVirtual(T) {
             _ = hash;
-            return getVirtual(name);
+            return getVirtual(allocator, name);
         }
     };
 
@@ -277,8 +278,8 @@ fn virtualMethodNames(comptime T: type) []const []const u8 {
 }
 
 pub fn registerMethod(comptime T: type, comptime name: DeclEnum(T)) void {
-    const class_name = StringName.fromComptimeLatin1(meta.typeShortName(T));
-    const method_name = StringName.fromComptimeLatin1(@tagName(name));
+    var class_name = StringName.fromComptimeLatin1(meta.typeShortName(T));
+    var method_name = StringName.fromComptimeLatin1(@tagName(name));
 
     const MethodType = @TypeOf(@field(T, @tagName(name)));
     const fn_info = @typeInfo(MethodType).@"fn";
@@ -288,25 +289,13 @@ pub fn registerMethod(comptime T: type, comptime name: DeclEnum(T)) void {
 
     const return_value: classdb.PropertyInfo = .{
         .type = .forType(ReturnType),
-        .name = &StringName.empty,
-        .class_name = &StringName.empty,
-        .hint = .property_hint_none,
-        .hint_string = &String.empty,
-        .usage = .property_usage_none,
     };
 
     const arg_infos: [arg_count]classdb.PropertyInfo = comptime blk: {
         var infos: [arg_count]classdb.PropertyInfo = undefined;
         for (0..arg_count) |i| {
             const ArgType = Args[i + 1].type.?;
-            infos[i] = .{
-                .type = Variant.Tag.forType(ArgType),
-                .name = &StringName.empty,
-                .class_name = &StringName.empty,
-                .hint = .property_hint_none,
-                .hint_string = &String.empty,
-                .usage = .property_usage_none,
-            };
+            infos[i] = .{ .type = .forType(ArgType) };
         }
         break :blk infos;
     };
@@ -351,21 +340,15 @@ pub fn registerSignal(comptime T: type, comptime S: type) void {
     const signal_name = StringName.fromComptimeLatin1(meta.signalName(S));
 
     const fields = @typeInfo(S).@"struct".fields;
-    const arg_info = comptime blk: {
-        var infos: [fields.len]classdb.PropertyInfo = undefined;
-        for (fields, 0..) |field, i| {
-            const name = StringName.fromComptimeLatin1(field.name);
-            infos[i] = .{
-                .type = .forType(field.type),
-                .name = &name,
-                .class_name = &StringName.empty,
-                .hint = .property_hint_none,
-                .hint_string = &String.empty,
-                .usage = .property_usage_none,
-            };
-        }
-        break :blk infos;
-    };
+    var arg_info: [fields.len]classdb.PropertyInfo = undefined;
+    var names: [fields.len]StringName = undefined;
+    inline for (fields, 0..) |field, i| {
+        names[i] = StringName.fromComptimeLatin1(field.name);
+        arg_info[i] = .{
+            .type = .forType(field.type),
+            .name = &names[i],
+        };
+    }
 
     classdb.registerSignal(&class_name, &signal_name, &arg_info);
 }

--- a/gdzig_bindgen/Context.zig
+++ b/gdzig_bindgen/Context.zig
@@ -31,6 +31,7 @@ enums: StringArrayHashMap(Enum) = .empty,
 flags: StringArrayHashMap(Flag) = .empty,
 interface: Interface = .empty,
 modules: StringArrayHashMap(Module) = .empty,
+native_structures: StringHashMap(void) = .empty,
 
 symbol_lookup: StringHashMap(Symbol) = .empty,
 
@@ -212,6 +213,7 @@ fn parseClasses(self: *Context) !void {
 
     for (self.api.native_structures) |ns| {
         try self.engine_classes.put(self.allocator(), ns.name, false);
+        try self.native_structures.put(self.allocator(), ns.name, {});
     }
 }
 

--- a/gdzig_bindgen/Context/type.zig
+++ b/gdzig_bindgen/Context/type.zig
@@ -48,7 +48,14 @@ pub const Type = union(enum) {
         .{ "int16", Type{ .int = "i16" } },
         .{ "int32", Type{ .int = "i32" } },
         .{ "int64", Type{ .int = "i64" } },
+        .{ "int8_t", Type{ .int = "i8" } },
+        .{ "int16_t", Type{ .int = "i16" } },
+        .{ "int32_t", Type{ .int = "i32" } },
+        .{ "int64_t", Type{ .int = "i64" } },
         .{ "uint8_t", Type{ .int = "u8" } },
+        .{ "uint16_t", Type{ .int = "u16" } },
+        .{ "uint32_t", Type{ .int = "u32" } },
+        .{ "uint64_t", Type{ .int = "u64" } },
         .{ "uint8", Type{ .int = "u8" } },
         .{ "uint16", Type{ .int = "u16" } },
         .{ "uint32", Type{ .int = "u32" } },
@@ -59,7 +66,7 @@ pub const Type = union(enum) {
     const meta_overrides: std.StaticStringMap(Type) = .initComptime(.{});
 
     pub fn from(allocator: Allocator, name: []const u8, is_meta: bool, ctx: *const Context) !Type {
-        var normalized = name;
+        var normalized = mem.trim(u8, name, " ");
 
         const n = mem.count(u8, normalized, ",");
         if (n > 0) {

--- a/gdzig_bindgen/codegen.zig
+++ b/gdzig_bindgen/codegen.zig
@@ -582,19 +582,19 @@ fn writeClassFunctionObjectPtr(w: *CodeWriter, class: *const Context.Class, func
 
 fn writeClassVirtualDispatch(w: *CodeWriter, class: *const Context.Class, ctx: *const Context) !void {
     if (class.base) |base| {
-        try w.printLine("pub const VTable = {s}.VTable.extend({s}, .{{", .{ class.name, base });
-
-        w.indent += 1;
-        for (class.functions.values()) |*function| {
-            if (function.mode == .final) continue;
-            try w.printLine("\"{s}\",", .{function.name});
-        }
-        w.indent -= 1;
-
-        try w.writeLine("});\n");
+        try w.printLine("pub const VTable = {s}.VTable.extend({s}, .{{", .{ base, class.name });
     } else {
-        // The root Object has its VTable defined in Object.mixin.zig
+        try w.printLine("pub const VTable = gdzig_object.VTable({s}, .{{", .{class.name});
     }
+
+    w.indent += 1;
+    for (class.functions.values()) |*function| {
+        if (function.mode == .final) continue;
+        try w.printLine("\"{s}\",", .{function.name});
+    }
+    w.indent -= 1;
+
+    try w.writeLine("});\n");
 
     for (class.functions.values()) |*function| {
         if (function.mode == .final) continue;
@@ -994,8 +994,10 @@ fn writeImports(w: *CodeWriter, root: []const u8, imports: *const Context.Import
             try w.printLine("const {1s} = @import(\"{0s}/global.zig\").{1s};", .{ root, import.* });
         } else if (ctx.interface.typedefs.contains(import.*)) {
             try w.printLine("const {0s} = @import(\"gdextension\").{0s};", .{import.*});
+        } else if (ctx.native_structures.contains(import.*)) {
+            try w.printLine("const {0s} = @import(\"gdextension\").{0s};", .{import.*});
         } else {
-            // TODO: native structures?
+            // Unknown type - skip
         }
     }
 }


### PR DESCRIPTION
this is not tested and probably not compiling, but it's the general approach:

- Zig idiomatic wrappers for extension registration methods in `godot.classdb` -- probably going to move this to a ClassDB mixin
- rewrote `godot.register` so:
  - none of the methods allocate
  - uses the more idiomatic classdb methods instead of the raw C functions
  - `registerClass` accepts an allocator that will be used to allocate any instance of this class
  - classes with `init/deinit` methods can accept that allocator to suballocate
  - `init`/`deinit`/`getPropertyList`/`destroyPropertyList` can return an Allocator.Error

basically, properly brings Zig allocators to gdzig

there is still work to do to wrap this PR up but I am opening it to begin discussion