### PR TITLE
static string map vtable

### DIFF
--- a/gdzig/builtin/String.mixin.zig
+++ b/gdzig/builtin/String.mixin.zig
@@ -156,7 +156,7 @@ pub inline fn fromNullTerminatedWideChars(wc: [:0]const c_int) String {
 /// **Since Godot 4.1**
 pub inline fn toLatin1Buf(self: *const String, buffer: []u8) []u8 {
     // These functions all return the number of characters and not byte
-    @memset(&buffer, 0);
+    @memset(buffer, 0);
     _ = raw.stringToLatin1Chars(self.constPtr(), @ptrCast(buffer.ptr), @intCast(buffer.len));
     const len = std.mem.indexOfSentinel(u8, 0, @ptrCast(buffer.ptr));
     return buffer[0..len];
@@ -171,7 +171,7 @@ pub inline fn toLatin1Buf(self: *const String, buffer: []u8) []u8 {
 /// **Since Godot 4.1**
 pub inline fn toUtf8Buf(self: *const String, buffer: []u8) []u8 {
     // These functions all return the number of characters and not bytes
-    @memset(&buffer, 0);
+    @memset(buffer, 0);
     _ = raw.stringToUtf8Chars(self.constPtr(), @ptrCast(buffer.ptr), @intCast(buffer.len));
     const len = std.mem.indexOfSentinel(u8, 0, @ptrCast(buffer.ptr));
     return buffer[0..len];
@@ -186,7 +186,7 @@ pub inline fn toUtf8Buf(self: *const String, buffer: []u8) []u8 {
 /// **Since Godot 4.1**
 pub inline fn toUtf16Buf(self: *const String, buffer: []u16) []u16 {
     // These functions all return the number of characters and not bytes
-    @memset(&buffer, 0);
+    @memset(buffer, 0);
     _ = raw.stringToUtf16Chars(self.constPtr(), @ptrCast(buffer.ptr), @intCast(buffer.len));
     const len = std.mem.indexOfSentinel(u16, 0, @ptrCast(buffer.ptr));
     return buffer[0..len];
@@ -213,7 +213,7 @@ pub inline fn toUtf32Buf(self: *const String, buffer: []u32) []u32 {
 /// **Since Godot 4.1**
 pub inline fn toWideChars(self: *const String, buffer: []c_int) []c_int {
     // These functions all return the number of characters and not bytes
-    @memset(&buffer, 0);
+    @memset(buffer, 0);
     _ = raw.stringToWideChars(self.constPtr(), @ptrCast(buffer.ptr), @intCast(buffer.len));
     const len = std.mem.indexOfSentinel(c_int, 0, @ptrCast(buffer.ptr));
     return buffer[0..len];

--- a/gdzig/object.zig
+++ b/gdzig/object.zig
@@ -238,6 +238,193 @@ fn assertCanInitialize(comptime T: type) void {
     }
 }
 
+/// Comptime vtable for virtual method dispatch using StaticStringMap.
+/// method_names is an array of Zig method names (camelCase with _ prefix).
+/// The VTable computes snake_case keys at comptime for O(1) lookup.
+pub fn VTable(comptime T: type, comptime method_names: anytype) type {
+    return struct {
+        const implemented_count = countImplemented();
+        const map: std.StaticStringMap(c.GDExtensionClassCallVirtual) = .initComptime(blk: {
+            var kvs: [implemented_count]struct { []const u8, c.GDExtensionClassCallVirtual } = undefined;
+            var idx: usize = 0;
+            for (method_names) |method_name| {
+                if (findMethod(method_name)) |wrapper| {
+                    // Convert camelCase method name to snake_case for lookup key
+                    kvs[idx] = .{ toSnakeCase(method_name), wrapper };
+                    idx += 1;
+                }
+            }
+            break :blk &kvs;
+        });
+
+        fn countImplemented() usize {
+            @setEvalBranchQuota(10000);
+            var count: usize = 0;
+            for (method_names) |name| {
+                if (findMethod(name) != null) count += 1;
+            }
+            return count;
+        }
+
+        fn findMethod(comptime method_name: []const u8) c.GDExtensionClassCallVirtual {
+            @setEvalBranchQuota(10000);
+            inline for (selfAndAncestorsOf(T)) |Owner| {
+                if (@hasDecl(Owner, method_name)) {
+                    const method = @field(Owner, method_name);
+                    const FnType = @TypeOf(method);
+                    const fn_info = @typeInfo(FnType).@"fn";
+                    const ReturnType = fn_info.return_type orelse void;
+
+                    const param_count = fn_info.params.len;
+                    if (param_count == 1) {
+                        // Only self parameter - generate simpler wrapper
+                        const Wrapper = struct {
+                            fn call(p_instance: c.GDExtensionClassInstancePtr, _: [*]const c.GDExtensionConstTypePtr, p_ret: c.GDExtensionTypePtr) callconv(.c) void {
+                                const instance: *Owner = @ptrCast(@alignCast(p_instance));
+                                if (ReturnType == void) {
+                                    method(instance);
+                                } else {
+                                    const result = method(instance);
+                                    const ret: *ReturnType = @ptrCast(@alignCast(p_ret));
+                                    ret.* = result;
+                                }
+                            }
+                        };
+                        return @ptrCast(&Wrapper.call);
+                    } else {
+                        // Multiple parameters - build args tuple
+                        const Wrapper = struct {
+                            fn call(p_instance: c.GDExtensionClassInstancePtr, p_args: [*]const c.GDExtensionConstTypePtr, p_ret: c.GDExtensionTypePtr) callconv(.c) void {
+                                const instance: *Owner = @ptrCast(@alignCast(p_instance));
+                                var args: std.meta.ArgsTuple(FnType) = undefined;
+                                args[0] = instance;
+                                inline for (1..param_count) |j| {
+                                    const Arg = fn_info.params[j].type.?;
+                                    args[j] = @as(*const Arg, @ptrCast(@alignCast(p_args[j - 1]))).*;
+                                }
+                                if (ReturnType == void) {
+                                    @call(.always_inline, method, args);
+                                } else {
+                                    const result = @call(.always_inline, method, args);
+                                    const ret: *ReturnType = @ptrCast(@alignCast(p_ret));
+                                    ret.* = result;
+                                }
+                            }
+                        };
+                        return @ptrCast(&Wrapper.call);
+                    }
+                }
+            }
+            return null;
+        }
+
+        /// Convert _camelCase to _snake_case at comptime.
+        /// Handles acronyms: consecutive uppercase letters are grouped,
+        /// but the last one starts a new word if followed by lowercase.
+        /// e.g., "_enterTree" -> "_enter_tree"
+        ///       "_getHTTPResponse" -> "_get_http_response"
+        ///       "_parseURLString" -> "_parse_url_string"
+        ///       "_getID" -> "_get_id"
+        fn toSnakeCase(comptime input: []const u8) []const u8 {
+            return comptime &SnakeCaseConverter(input).value;
+        }
+
+        fn SnakeCaseConverter(comptime input: []const u8) type {
+            const len = snakeCaseLen(input);
+            return struct {
+                const value: [len]u8 = blk: {
+                    var result: [len]u8 = undefined;
+                    var j: usize = 0;
+                    for (0..input.len) |i| {
+                        const ch = input[i];
+                        if (ch >= 'A' and ch <= 'Z') {
+                            const prev_lower = i > 0 and input[i - 1] >= 'a' and input[i - 1] <= 'z';
+                            const next_lower = i + 1 < input.len and input[i + 1] >= 'a' and input[i + 1] <= 'z';
+                            const prev_upper = i > 0 and input[i - 1] >= 'A' and input[i - 1] <= 'Z';
+                            if (prev_lower or (prev_upper and next_lower)) {
+                                result[j] = '_';
+                                j += 1;
+                            }
+                            result[j] = ch - 'A' + 'a';
+                        } else {
+                            result[j] = ch;
+                        }
+                        j += 1;
+                    }
+                    break :blk result;
+                };
+            };
+        }
+
+        fn snakeCaseLen(comptime input: []const u8) usize {
+            var extra: usize = 0;
+            for (0..input.len) |i| {
+                const ch = input[i];
+                if (ch >= 'A' and ch <= 'Z') {
+                    const prev_lower = i > 0 and input[i - 1] >= 'a' and input[i - 1] <= 'z';
+                    const next_lower = i + 1 < input.len and input[i + 1] >= 'a' and input[i + 1] <= 'z';
+                    const prev_upper = i > 0 and input[i - 1] >= 'A' and input[i - 1] <= 'Z';
+                    if (prev_lower or (prev_upper and next_lower)) {
+                        extra += 1;
+                    }
+                }
+            }
+            return input.len + extra;
+        }
+
+        pub fn has(name: []const u8) bool {
+            return map.has(name);
+        }
+
+        pub fn get(name: []const u8) c.GDExtensionClassCallVirtual {
+            return map.get(name) orelse null;
+        }
+
+        /// Extend this vtable with additional methods from a derived type.
+        pub fn extend(comptime Derived: type, comptime override_names: anytype) type {
+            return VTable(Derived, combineNames(override_names));
+        }
+
+        fn countNew(comptime override_names: anytype) usize {
+            @setEvalBranchQuota(10000);
+            var count: usize = 0;
+            outer: for (override_names) |override_name| {
+                for (method_names) |base_name| {
+                    if (std.mem.eql(u8, override_name, base_name)) {
+                        continue :outer;
+                    }
+                }
+                count += 1;
+            }
+            return count;
+        }
+
+        fn combineNames(comptime override_names: anytype) [method_names.len + countNew(override_names)][]const u8 {
+            @setEvalBranchQuota(10000);
+            var combined: [method_names.len + countNew(override_names)][]const u8 = undefined;
+
+            // Copy base names
+            for (0..method_names.len) |i| {
+                combined[i] = method_names[i];
+            }
+
+            // Add override names that aren't already in base
+            var i: usize = 0;
+            outer: for (override_names) |override_name| {
+                for (method_names) |base_name| {
+                    if (std.mem.eql(u8, override_name, base_name)) {
+                        continue :outer;
+                    }
+                }
+                combined[method_names.len + i] = override_name;
+                i += 1;
+            }
+
+            return combined;
+        }
+    };
+}
+
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 
@@ -271,3 +458,47 @@ const Callable = godot.builtin.Callable;
 const String = godot.builtin.String;
 const StringName = godot.builtin.StringName;
 const Variant = godot.builtin.Variant;
+
+test "VTable snake_case conversion" {
+    const TestVTable = VTable(struct {
+        pub fn _enterTree(_: *@This()) void {}
+        pub fn _getHTTPResponse(_: *@This()) void {}
+        pub fn _parseURLString(_: *@This()) void {}
+        pub fn _getID(_: *@This()) void {}
+        pub fn _ready(_: *@This()) void {}
+        pub fn _physics2DProcess(_: *@This()) void {}
+        pub fn _physics3DProcess(_: *@This()) void {}
+        pub fn _get2DPosition(_: *@This()) void {}
+    }, .{ "_enterTree", "_getHTTPResponse", "_parseURLString", "_getID", "_ready", "_physics2DProcess", "_physics3DProcess", "_get2DPosition" });
+
+    try std.testing.expect(TestVTable.has("_enter_tree"));
+    try std.testing.expect(TestVTable.has("_get_http_response"));
+    try std.testing.expect(TestVTable.has("_parse_url_string"));
+    try std.testing.expect(TestVTable.has("_get_id"));
+    try std.testing.expect(TestVTable.has("_ready"));
+    try std.testing.expect(TestVTable.has("_physics2d_process"));
+    try std.testing.expect(TestVTable.has("_physics3d_process"));
+    try std.testing.expect(TestVTable.has("_get2d_position"));
+    try std.testing.expect(!TestVTable.has("_not_implemented"));
+}
+
+test "VTable extend combines method names" {
+    const BaseType = struct {
+        pub fn _ready(_: *@This()) void {}
+        pub fn _process(_: *@This()) void {}
+    };
+    const Base = VTable(BaseType, .{ "_ready", "_process" });
+
+    // Derived implements _ready (override) and _enterTree (new), but also _process (inherited)
+    const DerivedType = struct {
+        pub fn _ready(_: *@This()) void {}
+        pub fn _process(_: *@This()) void {}
+        pub fn _enterTree(_: *@This()) void {}
+    };
+    const Derived = Base.extend(DerivedType, .{ "_ready", "_enterTree" });
+
+    // All methods should be findable
+    try std.testing.expect(Derived.has("_ready"));
+    try std.testing.expect(Derived.has("_process")); // from base method_names
+    try std.testing.expect(Derived.has("_enter_tree")); // new in derived
+}

--- a/gdzig_test/gdzig_test.zig
+++ b/gdzig_test/gdzig_test.zig
@@ -9,7 +9,9 @@ pub fn runInit(comptime testcase: type, current: godot.InitializationLevel) void
     if (@hasDecl(testcase, "init")) {
         callTestFn(testcase.init) catch |e| fail(e);
     }
-    callTestFn(testcase.run) catch |e| fail(e);
+    if (@hasDecl(testcase, "run")) {
+        callTestFn(testcase.run) catch |e| fail(e);
+    }
 }
 
 pub fn runDeinit(comptime testcase: type, current: godot.InitializationLevel) void {

--- a/tests/vtable/VTableNode.zig
+++ b/tests/vtable/VTableNode.zig
@@ -1,0 +1,28 @@
+const VTableNode = @This();
+
+pub var last_instance: ?*VTableNode = null;
+
+base: *Node,
+ready_called: bool = false,
+enter_tree_called: bool = false,
+exit_tree_called: bool = false,
+
+pub fn init(base: *Node) VTableNode {
+    return VTableNode{ .base = base };
+}
+
+pub fn _ready(self: *VTableNode) void {
+    last_instance = self;
+    self.ready_called = true;
+}
+
+pub fn _enterTree(self: *VTableNode) void {
+    self.enter_tree_called = true;
+}
+
+pub fn _exitTree(self: *VTableNode) void {
+    self.exit_tree_called = true;
+}
+
+const godot = @import("gdzig");
+const Node = godot.class.Node;

--- a/tests/vtable/test.tscn
+++ b/tests/vtable/test.tscn
@@ -1,0 +1,3 @@
+[gd_scene format=3]
+
+[node name="Root" type="VTableNode"]

--- a/tests/vtable/test.zig
+++ b/tests/vtable/test.zig
@@ -1,0 +1,14 @@
+pub fn init() void {
+    godot.registerClass(VTableNode, .{});
+}
+
+pub fn deinit() !void {
+    const node = VTableNode.last_instance orelse return error.NoInstance;
+    try testing.expect(node.enter_tree_called);
+    try testing.expect(node.ready_called);
+    try testing.expect(node.exit_tree_called);
+}
+
+const godot = @import("gdzig");
+const testing = @import("gdzig_test");
+const VTableNode = @import("VTableNode.zig");


### PR DESCRIPTION
this uses a `StaticStringMap` for virtual method dispatch.

before, dispatch would basically `if (method_name == "_process")` for every virtual method until it found the right one; which was O(N) lookup.

now, it is O(1) lookup to an inlined wrapper function, which should minimize overhead dramatically.