### PR TITLE
include mixins for all class ancestors

### DIFF
--- a/gdzig/class/FileAccess.mixin.zig
+++ b/gdzig/class/FileAccess.mixin.zig
@@ -5,7 +5,7 @@
 /// @see FileAccess::store_buffer()
 ///
 /// **Since Godot 4.1**
-pub inline fn writeBuf(self: *FileAccess, buf: []const u8) void {
+pub inline fn writeBuf(self: *Self, buf: []const u8) void {
     raw.fileAccessStoreBuffer(
         self.ptr(),
         @ptrCast(buf.ptr),
@@ -20,7 +20,7 @@ pub inline fn writeBuf(self: *FileAccess, buf: []const u8) void {
 /// Returns a sub-slice of the buffer containing the read data.
 ///
 /// **Since Godot 4.1**
-pub inline fn readBuf(self: *const FileAccess, buf: []u8) []u8 {
+pub inline fn readBuf(self: *const Self, buf: []u8) []u8 {
     const len = @as(usize, @intCast(raw.fileAccessGetBuffer(
         self.constPtr(),
         @ptrCast(buf.ptr),
@@ -34,4 +34,4 @@ pub inline fn readBuf(self: *const FileAccess, buf: []u8) []u8 {
 const raw: *Interface = &@import("../gdzig.zig").raw;
 
 const Interface = @import("../Interface.zig");
-const FileAccess = @import("./file_access.zig").FileAccess;
+const Self = @import("./file_access.zig").FileAccess;

--- a/gdzig/class/Image.mixin.zig
+++ b/gdzig/class/Image.mixin.zig
@@ -1,7 +1,7 @@
 /// Returns a mutable slice of the internal Image buffer.
 ///
 /// **Since Godot 4.3**
-pub inline fn slice(self: *Image) []u8 {
+pub inline fn slice(self: *Self) []u8 {
     const len = @as(usize, @intCast(self.getDataSize()));
     const p = @as([*]u8, @ptrCast(raw.imagePtr(self.ptr())));
     return p[0..len];
@@ -10,7 +10,7 @@ pub inline fn slice(self: *Image) []u8 {
 /// Returns a const slice of the internal Image buffer.
 ///
 /// **Since Godot 4.3**
-pub inline fn constSlice(self: *const Image) []const u8 {
+pub inline fn constSlice(self: *const Self) []const u8 {
     const len = @as(usize, @intCast(self.getDataSize()));
     const p = @as([*]const u8, @ptrCast(raw.imagePtr(@constCast(self.constPtr()))));
     return p[0..len];
@@ -21,4 +21,4 @@ pub inline fn constSlice(self: *const Image) []const u8 {
 const raw: *Interface = &@import("../gdzig.zig").raw;
 
 const Interface = @import("../Interface.zig");
-const Image = @import("./image.zig").Image;
+const Self = @import("./image.zig").Image;

--- a/gdzig/class/Object.mixin.zig
+++ b/gdzig/class/Object.mixin.zig
@@ -1,0 +1,51 @@
+// @mixin start
+
+/// Upcasts a child type to this type.
+pub fn upcast(value: anytype) *Self {
+    return oopz.upcast(*Self, value);
+}
+
+/// Downcasts a parent type to this type.
+///
+/// This operation will fail at compile time if Self does not inherit from `@TypeOf(value)`. However,
+/// since there is no guarantee that `value` is this type at runtime, this function has a runtime cost
+/// and may return `null`.
+pub fn downcast(value: anytype) ?*Self {
+    const T = comptime sw: switch (@typeInfo(@TypeOf(value))) {
+        .optional => |info| continue :sw @typeInfo(info.child),
+        .pointer => |info| break :sw info.child,
+        else => @compileError("downcasted value should be a pointer, found '" ++ @typeName(@TypeOf(value)) ++ "'"),
+    };
+    comptime oopz.assertIsA(T, Self);
+    const tag = raw.classdbGetClassTag(@ptrCast(&StringName.fromComptimeLatin1(self_name)));
+    const result = raw.objectCastTo(@ptrCast(value), tag);
+    if (result) |p| {
+        if (oopz.isOpaqueClass(T)) {
+            return @ptrCast(@alignCast(p));
+        } else {
+            const object: *anyopaque = raw.objectGetInstanceBinding(p, raw.library, null) orelse return null;
+            return @ptrCast(@alignCast(object));
+        }
+    } else {
+        return null;
+    }
+}
+
+/// Returns an opaque pointer to the object.
+pub fn ptr(self: *Self) *anyopaque {
+    return @ptrCast(self);
+}
+
+/// Returns a constant opaque pointer to the object.
+pub fn constPtr(self: *const Self) *const anyopaque {
+    return @ptrCast(self);
+}
+
+// @mixin stop
+
+const oopz = @import("oopz");
+const raw = &@import("../gdzig.zig").raw;
+const StringName = @import("../builtin.zig").StringName;
+
+const Self = @import("./object.zig").Object;
+const self_name = "Object";

--- a/gdzig/class/WorkerThreadPool.mixin.zig
+++ b/gdzig/class/WorkerThreadPool.mixin.zig
@@ -10,7 +10,7 @@
 ///
 /// **Since Godot 4.1**
 pub inline fn addNativeGroupTask(
-    self: *WorkerThreadPool,
+    self: *Self,
     comptime func: *const Task(void),
     elements: i32,
     tasks: i32,
@@ -34,7 +34,7 @@ pub inline fn addNativeGroupTask(
 ///
 /// **Since Godot 4.1**
 pub inline fn addNativeGroupTaskWithUserdata(
-    self: *WorkerThreadPool,
+    self: *Self,
     comptime Userdata: type,
     comptime func: *const Task(Userdata),
     userdata: *Userdata,
@@ -62,7 +62,7 @@ pub inline fn addNativeGroupTaskWithUserdata(
 ///
 /// **Since Godot 4.1**
 pub inline fn addNativeTask(
-    self: *WorkerThreadPool,
+    self: *Self,
     comptime func: *const Task(void),
     high_priority: bool,
     description: ?*const String,
@@ -80,7 +80,7 @@ pub inline fn addNativeTask(
 ///
 /// **Since Godot 4.1**
 pub inline fn addNativeTaskWithUserdata(
-    self: *WorkerThreadPool,
+    self: *Self,
     comptime Userdata: type,
     comptime func: *const Task(Userdata),
     userdata: *Userdata,
@@ -143,4 +143,4 @@ const raw: *Interface = &@import("../gdzig.zig").raw;
 const builtin = @import("../builtin.zig");
 const String = builtin.String;
 const Interface = @import("../Interface.zig");
-const WorkerThreadPool = @import("./worker_thread_pool.zig").WorkerThreadPool;
+const Self = @import("./worker_thread_pool.zig").WorkerThreadPool;

--- a/gdzig/class/XMLParser.mixin.zig
+++ b/gdzig/class/XMLParser.mixin.zig
@@ -3,7 +3,7 @@
 /// - **buf**: A slice containing the buffer data.
 ///
 /// **Since Godot 4.1**
-pub inline fn openBuf(self: *XMLParser, buf: []const u8) void {
+pub inline fn openBuf(self: *Self, buf: []const u8) void {
     raw.xmlParserOpenBuffer(self.ptr(), @ptrCast(buf.ptr), buf.len);
 }
 
@@ -12,4 +12,4 @@ pub inline fn openBuf(self: *XMLParser, buf: []const u8) void {
 const raw: *Interface = &@import("../gdzig.zig").raw;
 
 const Interface = @import("../Interface.zig");
-const XMLParser = @import("./xmlparser.zig").XMLParser;
+const Self = @import("./xmlparser.zig").XMLParser;


### PR DESCRIPTION
this lets us put helpers directly on `Object.mixin.zig` and all classes will receive them