### PR TITLE
remove create/destroy/unreference helpers

### DIFF
--- a/example/src/GuiNode.zig
+++ b/example/src/GuiNode.zig
@@ -15,6 +15,7 @@ pub fn create(allocator: *Allocator) !*GuiNode {
 }
 
 pub fn destroy(self: *GuiNode, allocator: *Allocator) void {
+    self.base.destroy();
     allocator.destroy(self);
 }
 
@@ -40,7 +41,7 @@ pub fn _enterTree(self: *GuiNode) void {
     defer res_name.deinit();
 
     const texture = ResourceLoader.load(res_name, .{}).?;
-    defer _ = texture.unreference();
+    defer if (texture.unreference()) texture.destroy();
     self.sprite = Sprite2D.init();
     self.sprite.setTexture(Texture2D.downcast(texture).?);
     self.sprite.setPosition(.initXY(400, 300));

--- a/example/src/SignalNode.zig
+++ b/example/src/SignalNode.zig
@@ -22,6 +22,7 @@ pub fn create(allocator: *Allocator) !*Self {
 }
 
 pub fn destroy(self: *Self, allocator: *Allocator) void {
+    self.base.destroy();
     allocator.destroy(self);
 }
 

--- a/example/src/SpriteNode.zig
+++ b/example/src/SpriteNode.zig
@@ -24,6 +24,7 @@ pub fn create(allocator: *Allocator) !*Self {
 }
 
 pub fn destroy(self: *Self, allocator: *Allocator) void {
+    self.base.destroy();
     allocator.destroy(self);
 }
 
@@ -42,7 +43,7 @@ pub fn _ready(self: *Self) void {
     defer logo_path.deinit();
 
     const tex = ResourceLoader.load(logo_path, .{}).?;
-    defer _ = tex.unreference();
+    defer if (tex.unreference()) tex.destroy();
 
     const sz = self.base.getParentAreaSize();
 

--- a/example/src/example.zig
+++ b/example/src/example.zig
@@ -41,11 +41,14 @@ pub const Extension = struct {
     }
 
     pub fn destroy(self: *Extension) void {
-        _ = self.gpa.deinit();
+        var gpa = self.gpa;
+        gpa.allocator().destroy(self);
+        assert(gpa.deinit() == .ok);
     }
 };
 
 const std = @import("std");
+const assert = std.debug.assert;
 const Allocator = std.mem.Allocator;
 const DebugAllocator = std.heap.DebugAllocator;
 const InitializationLevel = godot.InitializationLevel;

--- a/gdzig/class/Object.mixin.zig
+++ b/gdzig/class/Object.mixin.zig
@@ -1,5 +1,14 @@
 // @mixin start
 
+/// Immediately destroys the object. Prefer `queueFree` in most situations.
+pub fn destroy(self: *Self) void {
+    if (DestroyMeta.get(Object.upcast(self))) |destroy_meta| {
+        if (destroy_meta.engine_destroying) return;
+        destroy_meta.user_destroying = true;
+    }
+    raw.objectDestroy(self.ptr());
+}
+
 /// Upcasts a child type to this type.
 pub fn upcast(value: anytype) *Self {
     return oopz.upcast(*Self, value);
@@ -88,14 +97,18 @@ fn typeToken(comptime T: type) *anyopaque {
     }.token);
 }
 
+const DestroyMeta = @import("../register.zig").DestroyMeta;
+
 // @mixin stop
 
 const std = @import("std");
 
-const typeName = @import("../gdzig.zig").meta.typeName;
+const godot = @import("../gdzig.zig");
+const typeName = godot.meta.typeName;
+const Object = @import("object.zig").Object;
 
 const oopz = @import("oopz");
-const raw = &@import("../gdzig.zig").raw;
+const raw = &godot.raw;
 const StringName = @import("../builtin.zig").StringName;
 
 const c = @import("gdextension");

--- a/gdzig/gdzig.zig
+++ b/gdzig/gdzig.zig
@@ -125,28 +125,6 @@ pub fn signalName(comptime S: type) builtin.StringName {
     return .fromComptimeLatin1(meta.signalName(S));
 }
 
-/// Create any Godot object.
-pub fn create(comptime T: type) !*T {
-    comptime oopz.assertIsA(class.Object, T);
-
-    const Base = oopz.BaseOf(T);
-    const ptr = raw.classdbConstructObject2(@ptrCast(meta.typeName(T))) orelse return error.OutOfMemory;
-    const obj: *Base = @ptrCast(@alignCast(ptr));
-
-    return obj.asInstance(T) orelse @panic("Failed to create object");
-}
-
-/// Destroy any Godot object.
-pub fn destroy(obj: anytype) void {
-    raw.objectDestroy(class.Object.upcast(obj).ptr());
-}
-
-/// Unreference any `RefCounted` object.
-pub fn unreference(ref_counted: anytype) void {
-    const ref = class.RefCounted.upcast(ref_counted);
-    if (ref.unreference()) destroy(ref_counted);
-}
-
 pub const CallError = error{
     InvalidMethod,
     InvalidArgument,
@@ -165,7 +143,6 @@ pub const PropertyError = error{
 const std = @import("std");
 
 pub const c = @import("gdextension");
-const oopz = @import("oopz");
 
 pub const builtin = @import("builtin.zig");
 pub const class = @import("class.zig");

--- a/gdzig/object.zig
+++ b/gdzig/object.zig
@@ -1,7 +1,6 @@
 pub fn connect(obj: anytype, comptime S: type, callable: Callable) void {
-    var signal_name: StringName = .fromComptimeLatin1(comptime meta.signalName(S));
-    defer signal_name.deinit();
-
+    // Use a static StringName - no deinit needed since it's comptime
+    const signal_name: StringName = .fromComptimeLatin1(comptime meta.signalName(S));
     _ = obj.connect(signal_name, callable, .{});
 }
 

--- a/gdzig_bindgen/Context/Class.zig
+++ b/gdzig_bindgen/Context/Class.zig
@@ -97,6 +97,9 @@ pub fn fromApi(allocator: Allocator, api: GodotApi.Class, ctx: *const Context) !
 
     // Methods
     for (api.methods orelse &.{}) |method| {
+        // Skip 'destroy' on RefCounted classes - provided by mixin instead
+        if (self.is_refcounted and std.mem.eql(u8, method.name, "destroy")) continue;
+
         try self.functions.put(allocator, method.name, try Function.fromClass(allocator, self.name_api, self.has_singleton, method, ctx));
     }
 

--- a/tests/classdb/TestNode.zig
+++ b/tests/classdb/TestNode.zig
@@ -12,8 +12,8 @@ pub fn create() !*TestNode {
     return self;
 }
 
-pub fn destroy(instance: *TestNode) void {
-    testing.allocator.destroy(instance);
+pub fn destroy(self: *TestNode) void {
+    testing.allocator.destroy(self);
 }
 
 pub fn increment(self: *TestNode) void {

--- a/tests/classdb/test.zig
+++ b/tests/classdb/test.zig
@@ -3,8 +3,9 @@ pub fn init() void {
 }
 
 pub fn run() !void {
-    const node = godot.create(TestNode) catch return error.CreateFailed;
-    defer godot.destroy(node);
+    const node = TestNode.create() catch return error.CreateFailed;
+    defer node.base.destroy();
+    defer node.destroy();
 
     _ = Object.call(.upcast(node), .fromComptimeLatin1("increment"), .{});
     try testing.expectCall(node, "get_counter", .{}, @as(i64, 1));

--- a/tests/node_creation/test.zig
+++ b/tests/node_creation/test.zig
@@ -1,6 +1,6 @@
 pub fn run() !void {
     const node = godot.class.Node.init();
-    defer godot.destroy(node);
+    defer node.destroy();
 
     var name = node.getName();
     defer name.deinit();

--- a/tests/vtable/VTableNode.zig
+++ b/tests/vtable/VTableNode.zig
@@ -15,6 +15,7 @@ pub fn create(allocator: *const Allocator) !*VTableNode {
 }
 
 pub fn destroy(self: *VTableNode, allocator: *const Allocator) void {
+    self.base.destroy();
     allocator.destroy(self);
 }
 


### PR DESCRIPTION
this PR is the culmination of a bunch of work..

Godot's ownership model is really strange:

- extension classes provide create and destroy callbacks
  - extension classes should create their base engine class in their create callback
  - extension classes should _not destroy_ their engine classes in their destroy callback
- an engine class must have its instance set before the extension class can do anything with it

the asymmetry between create/destroy doesn't fit with Zig; we're expected to manage our memory. memory we create is ours to destroy. as a result it created a lot of hacks; forcing us to create/destroy our extension classes with helper methods, basically forfeiting control over our class creation/destruction -- very not Zig.

well, no longer! I have removed `godot.create`/`godot.destroy`/`godot.unreference`. you can create extension classes directly, and they just work.

you can also destroy the engine classes from within your extension class, as you would expect;

```zig
const MyClass = @This();

base: *Object,

pub fn create() !*MyClass {
    const self = try allocator.create(MyClass);
    self.* = .{ .base = .init() }; // future work to rename Object.init to Object.create
    self.base.setInstance(MyClass, self);
    return self;
}

pub fn destroy(self: *MyClass) void {
    self.base.destroy();
    allocator.destroy(self);
}

const allocator = godot.heap.engine_allocator;
```

elsewhere in your code, use it however you would normally!

```zig
const my_thing = try MyClass.create();
defer my_thing.destroy();
```

it all just works!

this PR also fixes all memory leaks in the example project as a plus :)

<img width="1980" height="1342" alt="Screenshot From 2025-12-13 15-30-27" src="https://github.com/user-attachments/assets/952fed36-4b43-4285-9881-55bd260ee32e" />
