### PR TITLE
remove `godot.typeName()` helper

### DIFF
--- a/gdzig/builtin/Array.mixin.zig
+++ b/gdzig/builtin/Array.mixin.zig
@@ -14,11 +14,9 @@ pub inline fn ref(self: *Array, from: *const Array) void {
 ///
 /// **Since Godot 4.1**
 pub inline fn setTyped(self: *Array, comptime T: type, script: ?*const Variant) void {
-    const typeName = @import("../gdzig.zig").typeName;
-
     const tag = Variant.Tag.forType(T);
-    const name = if (tag == .object) typeName(T).constPtr() else null;
-    raw.arraySetTyped(self.ptr(), @intFromEnum(tag), name, if (script) |s| s.constPtr() else null);
+    const name: StringName = .fromComptimeLatin1(@import("../meta.zig").typeShortName(T));
+    raw.arraySetTyped(self.ptr(), @intFromEnum(tag), if (tag == .object) name.constPtr() else null, if (script) |s| s.constPtr() else null);
 }
 
 /// Gets a pointer to a Variant in an Array.

--- a/gdzig/builtin/Dictionary.mixin.zig
+++ b/gdzig/builtin/Dictionary.mixin.zig
@@ -13,20 +13,20 @@ pub inline fn setTyped(
     key_script: ?*const Variant,
     value_script: ?*const Variant,
 ) void {
-    const typeName = @import("../gdzig.zig").typeName;
+    const meta = @import("../meta.zig");
 
     const key_tag = Variant.Tag.forType(K);
     const value_tag = Variant.Tag.forType(V);
-    const key_class_name = typeName(K);
-    const value_class_name = typeName(V);
+    const key_class_name: StringName = .fromComptimeLatin1(meta.typeShortName(K));
+    const value_class_name: StringName = .fromComptimeLatin1(meta.typeShortName(V));
 
     raw.dictionarySetTyped(
         self.ptr(),
         @intFromEnum(key_tag),
-        key_class_name.constPtr(),
+        if (key_tag == .object) key_class_name.constPtr() else null,
         if (key_script) |s| s.constPtr() else null,
         @intFromEnum(value_tag),
-        value_class_name.constPtr(),
+        if (value_tag == .object) value_class_name.constPtr() else null,
         if (value_script) |s| s.constPtr() else null,
     );
 }

--- a/gdzig/class/Object.mixin.zig
+++ b/gdzig/class/Object.mixin.zig
@@ -57,7 +57,7 @@ pub fn setInstance(self: *Self, comptime T: type, instance_: *T) void {
 
     const token = comptime typeToken(T);
 
-    raw.objectSetInstance(@ptrCast(self), @ptrCast(typeName(T)), @ptrCast(instance_));
+    raw.objectSetInstance(@ptrCast(self), @ptrCast(&StringName.fromComptimeLatin1(gdzig_meta.typeShortName(T))), @ptrCast(instance_));
     raw.objectSetInstanceBinding(@ptrCast(self), token, @ptrCast(instance_), &struct {
         const callbacks = c.GDExtensionInstanceBindingCallbacks{
             .create_callback = create_callback,
@@ -141,7 +141,6 @@ const DestroyMeta = @import("../register.zig").DestroyMeta;
 const std = @import("std");
 
 const godot = @import("../gdzig.zig");
-const typeName = godot.meta.typeName;
 const Callable = godot.builtin.Callable;
 const Object = @import("object.zig").Object;
 const Variant = godot.builtin.Variant;

--- a/gdzig/gdzig.zig
+++ b/gdzig/gdzig.zig
@@ -106,21 +106,6 @@ test {
 pub var interface: *Interface = &raw;
 pub var raw: Interface = undefined;
 
-pub fn typeName(comptime T: type) *builtin.StringName {
-    const Static = &struct {
-        const _ = meta.typeShortName(T);
-        var name: builtin.StringName = undefined;
-        var init: bool = false;
-    };
-
-    if (!Static.init) {
-        Static.name = builtin.StringName.fromComptimeLatin1(Static._);
-        Static.init = true;
-    }
-
-    return &Static.name;
-}
-
 pub const CallError = error{
     InvalidMethod,
     InvalidArgument,

--- a/gdzig/meta.zig
+++ b/gdzig/meta.zig
@@ -28,4 +28,3 @@ const case = @import("case");
 
 const godot = @import("gdzig.zig");
 const StringName = godot.builtin.StringName;
-pub const typeName = godot.typeName;

--- a/gdzig/object.zig
+++ b/gdzig/object.zig
@@ -21,8 +21,8 @@ pub fn downcast(comptime T: type, value: anytype) blk: {
         return null;
     }
 
-    const name = typeName(Child(T));
-    const tag = godot.interface.classdbGetClassTag(@ptrCast(name));
+    const name: StringName = .fromComptimeLatin1(meta.typeShortName(Child(T)));
+    const tag = godot.interface.classdbGetClassTag(@ptrCast(&name));
     const result = godot.interface.objectCastTo(@ptrCast(value), tag);
 
     if (result) |ptr| {
@@ -294,7 +294,6 @@ const c = godot.c;
 const meta = godot.meta;
 const PropertyHint = godot.global.PropertyHint;
 const PropertyUsageFlags = godot.global.PropertyUsageFlags;
-const typeName = meta.typeName;
 const Object = godot.class.Object;
 const RefCounted = godot.class.RefCounted;
 const Callable = godot.builtin.Callable;

--- a/gdzig/support.zig
+++ b/gdzig/support.zig
@@ -19,8 +19,8 @@ pub inline fn bindClassMethod(
 ) ClassMethod {
     const callback = struct {
         fn callback(string_name: godot.builtin.StringName) ClassMethod {
-            const class_name = godot.meta.typeName(T);
-            return godot.interface.classdbGetMethodBind(@ptrCast(class_name), @ptrCast(@constCast(&string_name)), hash).?;
+            const class_name: godot.builtin.StringName = .fromComptimeLatin1(godot.meta.typeShortName(T));
+            return godot.interface.classdbGetMethodBind(@ptrCast(&class_name), @ptrCast(@constCast(&string_name)), hash).?;
         }
     }.callback;
 

--- a/gdzig_bindgen/codegen.zig
+++ b/gdzig_bindgen/codegen.zig
@@ -374,7 +374,7 @@ fn writeClass(w: *CodeWriter, class: *const Context.Class, ctx: *const Context) 
             try w.printLine(
                 \\/// Allocates an empty {0s}.
                 \\pub fn init() *{0s} {{
-                \\    return @ptrCast(raw.classdbConstructObject(@ptrCast(typeName({0s}))).?);
+                \\    return @ptrCast(raw.classdbConstructObject(@ptrCast(&StringName.fromComptimeLatin1(self_name))).?);
                 \\}}
                 \\
             , .{class.name});
@@ -382,7 +382,7 @@ fn writeClass(w: *CodeWriter, class: *const Context.Class, ctx: *const Context) 
             try w.printLine(
                 \\/// Allocates an empty {0s}.
                 \\pub fn init() {0s} {{
-                \\    return @ptrCast(raw.classdbConstructObject(@ptrCast(typeName({0s}))).?);
+                \\    return @ptrCast(raw.classdbConstructObject(@ptrCast(&StringName.fromComptimeLatin1(self_name))).?);
                 \\}}
                 \\
             , .{class.name});
@@ -438,7 +438,6 @@ fn writeClass(w: *CodeWriter, class: *const Context.Class, ctx: *const Context) 
     // Imports
     try w.writeLine(
         \\const oopz = @import("oopz");
-        \\const typeName = @import("../gdzig.zig").typeName;
         \\const gdzig_object = @import("../object.zig");
     );
     try writeImports(w, "..", &class.imports, ctx);
@@ -469,11 +468,11 @@ fn writeClassFunction(w: *CodeWriter, class: *const Context.Class, function: *co
     try writeFunctionHeader(w, function, ctx);
 
     if (class.is_singleton) {
-        try w.printLine(
-            \\if (instance == null) {{
-            \\    instance = @ptrCast(raw.globalGetSingleton(@ptrCast(typeName({0s}))).?);
-            \\}}
-        , .{class.name});
+        try w.writeLine(
+            \\if (instance == null) {
+            \\    instance = @ptrCast(raw.globalGetSingleton(@ptrCast(&StringName.fromComptimeLatin1(self_name))).?);
+            \\}
+        );
     }
 
     if (function.is_vararg) {
@@ -482,7 +481,7 @@ fn writeClassFunction(w: *CodeWriter, class: *const Context.Class, function: *co
 
     try w.printLine(
         \\if ({0s}_ptr == null) {{
-        \\    {0s}_ptr = raw.classdbGetMethodBind(@ptrCast(typeName({2s})), @ptrCast(&StringName.fromComptimeLatin1("{1s}")), {3d});
+        \\    {0s}_ptr = raw.classdbGetMethodBind(@ptrCast(&StringName.fromComptimeLatin1("{2s}")), @ptrCast(&StringName.fromComptimeLatin1("{1s}")), {3d});
         \\}}
     , .{
         function.name,
@@ -1107,7 +1106,6 @@ fn writeInterface(ctx: *Context) !void {
         \\const builtin = @import("builtin.zig");
         \\const class = @import("class.zig");
         \\const global = @import("global.zig");
-        \\const typeName = @import("gdzig.zig").typeName;
     );
 
     try writer.flush();


### PR DESCRIPTION
this was a weird holdover from the original codebase. there's no reason to be hanging on to these `StringName`s and passing them around by reference. `StringName` is interned, constructing them is extremely fast, and we don't need to free them because they're backed by static memory 