### PR TITLE
simplify engine_alloctor and add tests

### DIFF
--- a/gdzig/heap.zig
+++ b/gdzig/heap.zig
@@ -1,4 +1,3 @@
-/// An allocator backed by the Godot Engine's internal allocator.
 pub const engine_allocator: Allocator = .{
     .ptr = undefined,
     .vtable = &.{
@@ -9,80 +8,53 @@ pub const engine_allocator: Allocator = .{
     },
 };
 
-fn alloc(_: *anyopaque, len: usize, alignment: Alignment, ret_addr: usize) ?[*]u8 {
-    _ = ret_addr;
+fn alloc(_: *anyopaque, len: usize, alignment: Alignment, _: usize) ?[*]u8 {
+    if (alignment == .@"1") {
+        return @ptrCast(raw.memAlloc(len) orelse return null);
+    }
 
-    // Allocate extra space for alignment plus space to store the original pointer
-    const ptr_size = @sizeOf(usize);
-    const unaligned_size = len + alignment.toByteUnits() - 1 + ptr_size;
-    const ptr = raw.memAlloc(unaligned_size) orelse return null;
+    const padding = alignment.toByteUnits();
+    const unaligned_ptr = raw.memAlloc(len + padding) orelse return null;
+    const unaligned_addr = @intFromPtr(unaligned_ptr);
+    const aligned_addr = alignment.forward(unaligned_addr + @sizeOf(u32));
 
-    // Calculate aligned address, ensuring space for the original pointer
-    const unaligned_addr = @intFromPtr(ptr);
-    const aligned_addr = alignment.forward(unaligned_addr + ptr_size);
-
-    // Store the original pointer just before the aligned address
-    @as(*usize, @ptrFromInt(aligned_addr - ptr_size)).* = unaligned_addr;
+    @as(*align(1) u32, @ptrFromInt(aligned_addr - @sizeOf(u32))).* = @intCast(aligned_addr - unaligned_addr);
 
     return @ptrFromInt(aligned_addr);
 }
 
-fn resize(_: *anyopaque, memory: []u8, alignment: Alignment, new_len: usize, ret_addr: usize) bool {
-    _ = memory;
-    _ = new_len;
-    _ = alignment;
-    _ = ret_addr;
-
+fn resize(_: *anyopaque, _: []u8, _: Alignment, _: usize, _: usize) bool {
     return false;
 }
 
-fn remap(_: *anyopaque, memory: []u8, alignment: Alignment, new_len: usize, ret_addr: usize) ?[*]u8 {
-    _ = ret_addr;
-
-    if (alignment.toByteUnits() > 1) {
-        // Get the original pointer that was stored just before the aligned address
-        const aligned_addr = @intFromPtr(memory.ptr);
-        const ptr_size = @sizeOf(usize);
-        const original_ptr_loc = @as(*usize, @ptrFromInt(aligned_addr - ptr_size));
-        const original_addr = original_ptr_loc.*;
-        const original_ptr = @as(*anyopaque, @ptrFromInt(original_addr));
-
-        // Calculate new size with alignment and space for storing the original pointer
-        const unaligned_size = new_len + alignment.toByteUnits() - 1 + ptr_size;
-
-        // Reallocate using Godot's memory function
-        const new_ptr = raw.memRealloc(original_ptr, unaligned_size) orelse return null;
-
-        // Calculate new aligned address, ensuring space for the original pointer
-        const new_unaligned_addr = @intFromPtr(new_ptr);
-        const new_aligned_addr = alignment.forward(new_unaligned_addr + ptr_size);
-
-        // Store the new original pointer just before the aligned address
-        const new_original_ptr_loc = @as(*usize, @ptrFromInt(new_aligned_addr - ptr_size));
-        new_original_ptr_loc.* = new_unaligned_addr;
-
-        return @ptrFromInt(new_aligned_addr);
-    } else {
-        // No alignment needed, reallocate directly
-        const new_ptr = raw.memRealloc(memory.ptr, new_len) orelse return null;
-        return @ptrCast(new_ptr);
+fn remap(_: *anyopaque, memory: []u8, alignment: Alignment, new_len: usize, _: usize) ?[*]u8 {
+    if (alignment == .@"1") {
+        return @ptrCast(raw.memRealloc(memory.ptr, new_len) orelse return null);
     }
+
+    const padding = alignment.toByteUnits();
+    const aligned_addr = @intFromPtr(memory.ptr);
+    const offset = @as(*align(1) u32, @ptrFromInt(aligned_addr - @sizeOf(u32))).*;
+
+    const new_unaligned_ptr = raw.memRealloc(@ptrFromInt(aligned_addr - offset), new_len + padding) orelse return null;
+    const new_unaligned_addr = @intFromPtr(new_unaligned_ptr);
+    const new_aligned_addr = alignment.forward(new_unaligned_addr + @sizeOf(u32));
+
+    @as(*align(1) u32, @ptrFromInt(new_aligned_addr - @sizeOf(u32))).* = @intCast(new_aligned_addr - new_unaligned_addr);
+
+    return @ptrFromInt(new_aligned_addr);
 }
 
-fn free(_: *anyopaque, memory: []u8, alignment: Alignment, ret_addr: usize) void {
-    _ = ret_addr;
-
-    if (alignment.toByteUnits() > 1) {
-        // The original pointer was stored just before the aligned address
-        const aligned_addr = @intFromPtr(memory.ptr);
-        const ptr_size = @sizeOf(usize);
-        const original_addr = @as(*usize, @ptrFromInt(aligned_addr - ptr_size)).*;
-        const original_ptr = @as(*anyopaque, @ptrFromInt(original_addr));
-        raw.memFree(original_ptr);
-    } else {
-        // No alignment was needed, free directly
+fn free(_: *anyopaque, memory: []u8, alignment: Alignment, _: usize) void {
+    if (alignment == .@"1") {
         raw.memFree(memory.ptr);
+        return;
     }
+
+    const aligned_addr = @intFromPtr(memory.ptr);
+    const offset = @as(*align(1) u32, @ptrFromInt(aligned_addr - @sizeOf(u32))).*;
+
+    raw.memFree(@ptrFromInt(aligned_addr - offset));
 }
 
 const std = @import("std");

--- a/tests/allocator/test.zig
+++ b/tests/allocator/test.zig
@@ -1,0 +1,57 @@
+pub const level: godot.InitializationLevel = .core;
+
+pub fn run() !void {
+    try testAllocFree(.@"1");
+    try testAllocFree(.@"16");
+
+    try testRemap(.@"1");
+    try testRemap(.@"16");
+
+    try testRepeatedRemap();
+}
+
+fn testAllocFree(comptime alignment: Alignment) !void {
+    const mem = try testing.allocator.alignedAlloc(u8, alignment, 64);
+    defer testing.allocator.free(mem);
+
+    try testing.expect(alignment.check(@intFromPtr(mem.ptr)));
+    @memset(mem, 0xAB);
+}
+
+fn testRemap(comptime alignment: Alignment) !void {
+    var mem = try testing.allocator.alignedAlloc(u8, alignment, 32);
+
+    for (mem, 0..) |*byte, i| {
+        byte.* = @truncate(i);
+    }
+
+    mem = try testing.allocator.realloc(mem, 128);
+
+    try testing.expect(alignment.check(@intFromPtr(mem.ptr)));
+    for (mem[0..32], 0..) |byte, i| {
+        try testing.expectEqual(@as(u8, @truncate(i)), byte);
+    }
+
+    testing.allocator.free(mem);
+}
+
+fn testRepeatedRemap() !void {
+    var mem = try testing.allocator.alignedAlloc(u8, .@"16", 16);
+    @memset(mem, 0x42);
+
+    mem = try testing.allocator.realloc(mem, 64);
+    mem = try testing.allocator.realloc(mem, 256);
+    mem = try testing.allocator.realloc(mem, 32);
+
+    for (mem[0..16]) |byte| {
+        try testing.expectEqual(@as(u8, 0x42), byte);
+    }
+
+    testing.allocator.free(mem);
+}
+
+const std = @import("std");
+const Alignment = std.mem.Alignment;
+
+const godot = @import("gdzig");
+const testing = @import("gdzig_test");


### PR DESCRIPTION
this caught some errors in the original implementation. the new implementation is simpler, and saves memory in some cases.