### PR TITLE
refactor extension callbacks to init/enter/exit/deinit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ gdzig/class/*.zig
 gdzig/global/*.zig
 !gdzig/builtin/variant.zig
 !gdzig/class/vtable.zig
+!gdzig/global/initialization_level.zig
 !gdzig/**/*.mixin.zig
 !gdzig/**/*.replace.zig
 gdzig/builtin.zig

--- a/example/src/example.zig
+++ b/example/src/example.zig
@@ -2,30 +2,27 @@ comptime {
     godot.registerExtension(Extension, .{ .entry_symbol = "my_extension_init" });
 }
 
-pub const Extension = struct {
-    gpa: DebugAllocator(.{}),
-    allocator: Allocator,
+var gpa: DebugAllocator(.{}) = .init;
 
-    pub fn create() !*Extension {
-        var gpa: DebugAllocator(.{}) = .init;
-        const self = try gpa.allocator().create(Extension);
-        self.gpa = gpa;
-        self.allocator = self.gpa.allocator();
-        return self;
+pub const Extension = struct {
+    class_userdata: Allocator,
+
+    pub fn init() !Extension {
+        return .{ .class_userdata = gpa.allocator() };
     }
 
-    pub fn init(self: *Extension, level: InitializationLevel) void {
+    pub fn enter(self: *Extension, level: InitializationLevel) void {
         if (level == .scene) {
-            godot.registerClass(ExampleNode, .{ .userdata = &self.allocator });
+            godot.registerClass(ExampleNode, .{ .userdata = &self.class_userdata });
             godot.registerMethod(ExampleNode, .onTimeout);
             godot.registerMethod(ExampleNode, .onResized);
             godot.registerMethod(ExampleNode, .onItemFocused);
 
-            godot.registerClass(GuiNode, .{ .userdata = &self.allocator });
+            godot.registerClass(GuiNode, .{ .userdata = &self.class_userdata });
             godot.registerMethod(GuiNode, .onPressed);
             godot.registerMethod(GuiNode, .onToggled);
 
-            godot.registerClass(SignalNode, .{ .userdata = &self.allocator });
+            godot.registerClass(SignalNode, .{ .userdata = &self.class_userdata });
             godot.registerMethod(SignalNode, .onSignal1);
             godot.registerMethod(SignalNode, .onSignal2);
             godot.registerMethod(SignalNode, .onSignal3);
@@ -36,13 +33,12 @@ pub const Extension = struct {
             godot.registerSignal(SignalNode, SignalNode.Signal2);
             godot.registerSignal(SignalNode, SignalNode.Signal3);
 
-            godot.registerClass(SpriteNode, .{ .userdata = &self.allocator });
+            godot.registerClass(SpriteNode, .{ .userdata = &self.class_userdata });
         }
     }
 
-    pub fn destroy(self: *Extension) void {
-        var gpa = self.gpa;
-        gpa.allocator().destroy(self);
+    pub fn deinit(self: *Extension) void {
+        _ = self;
         assert(gpa.deinit() == .ok);
     }
 };
@@ -51,7 +47,7 @@ const std = @import("std");
 const assert = std.debug.assert;
 const Allocator = std.mem.Allocator;
 const DebugAllocator = std.heap.DebugAllocator;
-const InitializationLevel = godot.InitializationLevel;
+const InitializationLevel = godot.global.InitializationLevel;
 
 const godot = @import("gdzig");
 

--- a/gdzig/gdzig.zig
+++ b/gdzig/gdzig.zig
@@ -26,7 +26,6 @@ pub const registerClass = register.registerClass;
 pub const registerExtension = register.registerExtension;
 pub const registerMethod = register.registerMethod;
 pub const registerSignal = register.registerSignal;
-pub const InitializationLevel = register.InitializationLevel;
 
 const DispatchTable = @import("DispatchTable.zig");
 

--- a/gdzig/global.mixin.zig
+++ b/gdzig/global.mixin.zig
@@ -1,0 +1,1 @@
+pub const InitializationLevel = @import("global/initialization_level.zig").InitializationLevel;

--- a/gdzig/global/initialization_level.zig
+++ b/gdzig/global/initialization_level.zig
@@ -1,0 +1,6 @@
+pub const InitializationLevel = enum(c_int) {
+    core = 0,
+    servers = 1,
+    scene = 2,
+    editor = 3,
+};

--- a/gdzig/register.zig
+++ b/gdzig/register.zig
@@ -4,14 +4,9 @@ pub const ExtensionOptions = struct {
 };
 
 pub fn registerExtension(comptime T: type, comptime opt: ExtensionOptions) void {
-    const return_type = @typeInfo(@TypeOf(T.create)).@"fn".return_type.?;
-    const actual_type = switch (@typeInfo(return_type)) {
-        .error_union => |eu| eu.payload,
-        else => return_type,
+    const Cache = struct {
+        var state: T = undefined;
     };
-
-    assert(@typeInfo(actual_type) == .pointer);
-    assert(@typeInfo(actual_type).pointer.child == T);
 
     @export(&struct {
         fn entrypoint(
@@ -22,34 +17,47 @@ pub fn registerExtension(comptime T: type, comptime opt: ExtensionOptions) void 
             raw.* = .init(p_get_proc_address.?, p_library.?);
             raw.getGodotVersion(@ptrCast(&gdzig.version));
 
-            const self = if (@typeInfo(return_type) == .error_union)
-                T.create() catch return @intFromBool(false)
-            else
-                T.create();
+            Cache.state = init() catch |err| {
+                std.log.err("Failed to initialize extension: {}", .{err});
+                return @intFromBool(false);
+            };
 
-            r_initialization.*.userdata = @ptrCast(@constCast(self));
-            r_initialization.*.initialize = @ptrCast(&init);
-            r_initialization.*.deinitialize = @ptrCast(&deinit);
+            r_initialization.*.userdata = @ptrCast(&Cache.state);
+            r_initialization.*.initialize = @ptrCast(&enter);
+            r_initialization.*.deinitialize = @ptrCast(&exit);
             r_initialization.*.minimum_initialization_level = @intFromEnum(opt.minimum_initialization_level);
 
             return @intFromBool(true);
         }
 
-        fn init(userdata: ?*anyopaque, p_level: c.GDExtensionInitializationLevel) callconv(.c) void {
-            const self: *T = @ptrCast(@alignCast(userdata.?));
-            const level: InitializationLevel = @enumFromInt(p_level);
-
+        fn init() anyerror!T {
             if (@hasDecl(T, "init")) {
-                self.init(level);
+                const return_type = @typeInfo(@TypeOf(T.init)).@"fn".return_type.?;
+                return if (@typeInfo(return_type) == .error_union)
+                    T.init()
+                else
+                    T.init();
+            } else {
+                comptime assertDefaultInitializable();
+                return .{};
             }
         }
 
-        fn deinit(userdata: ?*anyopaque, p_level: c.GDExtensionInitializationLevel) callconv(.c) void {
+        fn enter(userdata: ?*anyopaque, p_level: c.GDExtensionInitializationLevel) callconv(.c) void {
             const self: *T = @ptrCast(@alignCast(userdata.?));
             const level: InitializationLevel = @enumFromInt(p_level);
 
-            if (@hasDecl(T, "deinit")) {
-                self.deinit(level);
+            if (@hasDecl(T, "enter")) {
+                self.enter(level);
+            }
+        }
+
+        fn exit(userdata: ?*anyopaque, p_level: c.GDExtensionInitializationLevel) callconv(.c) void {
+            const self: *T = @ptrCast(@alignCast(userdata.?));
+            const level: InitializationLevel = @enumFromInt(p_level);
+
+            if (@hasDecl(T, "exit")) {
+                self.exit(level);
             }
 
             if (level == opt.minimum_initialization_level) {
@@ -58,18 +66,29 @@ pub fn registerExtension(comptime T: type, comptime opt: ExtensionOptions) void 
                 if (@hasDecl(T, "destroy")) self.destroy();
             }
         }
+
+        fn assertDefaultInitializable() void {
+            const info = @typeInfo(T);
+
+            if (info != .@"struct") @compileError(@typeName(T) ++ " is not a struct, and cannot be default-initialized. It must have an initializer function.");
+
+            comptime var missing: []const u8 = "";
+            for (info.@"struct".fields) |field| {
+                if (field.default_value_ptr == null) {
+                    missing = missing ++ if (missing.len > 0) ", " else "";
+                    missing = missing ++ "'" ++ field.name ++ "'";
+                }
+            }
+
+            if (missing.len > 0) {
+                @compileError("Cannot default-initialize '" ++ @typeName(T) ++ "' because field(s) " ++ missing ++ " are missing default values. Either provide default values for all fields, or implement 'pub fn init() " ++ @typeName(T) ++ " {}'.");
+            }
+        }
     }.entrypoint, .{
         .name = opt.entry_symbol,
         .linkage = .strong,
     });
 }
-
-pub const InitializationLevel = enum(c_int) {
-    core = 0,
-    servers = 1,
-    scene = 2,
-    editor = 3,
-};
 
 pub fn registerClass(comptime T: type, info: ClassInfo4(ClassUserdataOf(T))) void {
     const class_name = StringName.fromComptimeLatin1(meta.typeShortName(T));
@@ -570,6 +589,7 @@ const string = gdzig.string;
 const class = gdzig.class;
 const classdb = gdzig.class.ClassDb;
 const ClassInfo4 = gdzig.class.ClassDb.ClassInfo4;
+const InitializationLevel = gdzig.global.InitializationLevel;
 const String = gdzig.builtin.String;
 const StringName = gdzig.builtin.StringName;
 const Variant = gdzig.builtin.Variant;

--- a/gdzig_test/build.zig
+++ b/gdzig_test/build.zig
@@ -140,16 +140,12 @@ fn generateMain(b: *Build) Build.LazyPath {
         \\}
         \\
         \\pub const Extension = struct {
-        \\    pub fn create() *const Extension {
-        \\        return &.{};
-        \\    }
-        \\
-        \\    pub fn init(self: *const Extension, level: godot.InitializationLevel) void {
+        \\    pub fn enter(self: *Extension, level: InitializationLevel) void {
         \\        _ = self;
         \\        testing.runInit(testcase, level);
         \\    }
         \\
-        \\    pub fn deinit(self: *const Extension, level: godot.InitializationLevel) void {
+        \\    pub fn exit(self: *Extension, level: InitializationLevel) void {
         \\        _ = self;
         \\        testing.runDeinit(testcase, level);
         \\    }
@@ -157,6 +153,7 @@ fn generateMain(b: *Build) Build.LazyPath {
         \\
         \\const std = @import("std");
         \\const godot = @import("gdzig");
+        \\const InitializationLevel = godot.global.InitializationLevel;
         \\const testcase = @import("testcase");
         \\const testing = @import("gdzig_test");
     );

--- a/gdzig_test/gdzig_test.zig
+++ b/gdzig_test/gdzig_test.zig
@@ -1,5 +1,5 @@
-pub fn runInit(comptime testcase: type, current: godot.InitializationLevel) void {
-    const level: godot.InitializationLevel = if (@hasDecl(testcase, "level"))
+pub fn runInit(comptime testcase: type, current: InitializationLevel) void {
+    const level: InitializationLevel = if (@hasDecl(testcase, "level"))
         testcase.level
     else
         .scene;
@@ -14,8 +14,8 @@ pub fn runInit(comptime testcase: type, current: godot.InitializationLevel) void
     }
 }
 
-pub fn runDeinit(comptime testcase: type, current: godot.InitializationLevel) void {
-    const level: godot.InitializationLevel = if (@hasDecl(testcase, "level"))
+pub fn runDeinit(comptime testcase: type, current: InitializationLevel) void {
+    const level: InitializationLevel = if (@hasDecl(testcase, "level"))
         testcase.level
     else
         .scene;
@@ -95,5 +95,6 @@ pub const refAllDeclsRecursive = std.testing.refAllDeclsRecursive;
 pub const tmpDir = std.testing.tmpDir;
 
 const godot = @import("gdzig");
+const InitializationLevel = godot.global.InitializationLevel;
 const Object = godot.class.Object;
 const StringName = godot.builtin.StringName;

--- a/tests/allocator/test.zig
+++ b/tests/allocator/test.zig
@@ -1,4 +1,4 @@
-pub const level: godot.InitializationLevel = .core;
+pub const level: godot.global.InitializationLevel = .core;
 
 pub fn run() !void {
     try testAllocFree(.@"1");


### PR DESCRIPTION
having the `UserExtension` allocate itself was extremely awkward; realistically only one extension instance is running at a time so we can rely on static memory to just do `init`/`deinit`.

these conflict with the GDExtension callback `init`/`deinit`, which are actually methods; those have been renamed to `enter`/`exit`, so the lifecycle is:

1. `init() UserExtension` or `init() !UserExtension`
2. `enter(*UserExtension, .core) void`
3. `enter(*UserExtension, .servers) void`
4. `enter(*UserExtension, .scene) void`
5. `enter(*UserExtension, .editor) void`
6. `exit(*UserExtension, .editor) void`
7. `exit(*UserExtension, .scene) void`
8. `exit(*UserExtension, .servers) void`
9. `exit(*UserExtension, .core) void`
10. `deinit(*UserExtension) void`

all callbacks are optional, except `init` if `UserExtension` is not default initializable. `init` can optionally return an error union.

I'm open to bikeshedding `enter`/`exit`; maybe `start`/`stop` makes more sense?
