### PR TITLE
use a target-specific general purpose allocator

### DIFF
--- a/gdzig/register.zig
+++ b/gdzig/register.zig
@@ -129,17 +129,14 @@ fn ClassUserdataOf(comptime T: type) type {
 const PropertyListMeta = struct {
     len: usize = 0,
 
-    var gpa: if (builtin.is_test) void else DebugAllocator(.{}) = if (builtin.is_test) {} else .init;
-    var pool: MemoryPool(PropertyListMeta) = .init(gpa.allocator());
+    var gpa: GeneralPurposeAllocator = .init(gdzig.engine_allocator);
+    const allocator = gpa.allocator();
+    var pool: MemoryPool(PropertyListMeta) = .init(allocator);
 
     const callbacks: c.GDExtensionInstanceBindingCallbacks = .{
         .create_callback = &create,
         .free_callback = &free,
     };
-
-    fn allocator() Allocator {
-        return if (builtin.is_test) std.testing.allocator else gpa.allocator();
-    }
 
     fn create(_: ?*anyopaque, _: ?*anyopaque) callconv(.c) ?*anyopaque {
         return @ptrCast(pool.create() catch return null);
@@ -151,7 +148,7 @@ const PropertyListMeta = struct {
 
     pub fn cleanup() void {
         pool.deinit();
-        if (!builtin.is_test) assert(gpa.deinit() == .ok);
+        assert(gpa.deinit() == .ok);
     }
 };
 
@@ -160,8 +157,9 @@ pub const DestroyMeta = struct {
     user_destroying: bool = false,
     engine_destroying: bool = false,
 
-    var gpa: if (builtin.is_test) void else DebugAllocator(.{}) = if (builtin.is_test) {} else .init;
-    var pool: MemoryPool(DestroyMeta) = .init(gpa.allocator());
+    var gpa: GeneralPurposeAllocator = .init(gdzig.engine_allocator);
+    const allocator = gpa.allocator();
+    var pool: MemoryPool(PropertyListMeta) = .init(allocator);
 
     pub const callbacks: c.GDExtensionInstanceBindingCallbacks = .{
         .create_callback = &create,
@@ -183,7 +181,7 @@ pub const DestroyMeta = struct {
 
     pub fn cleanup() void {
         pool.deinit();
-        if (!builtin.is_test) assert(gpa.deinit() == .ok);
+        assert(gpa.deinit() == .ok);
     }
 };
 
@@ -565,8 +563,9 @@ const assert = std.debug.assert;
 const builtin = @import("builtin");
 
 const c = @import("gdextension");
+const common = @import("common");
+const GeneralPurposeAllocator = common.GeneralPurposeAllocator;
 const gdzig = @import("gdzig");
-const meta = @import("meta.zig");
 const string = gdzig.string;
 const class = gdzig.class;
 const classdb = gdzig.class.ClassDb;
@@ -575,3 +574,5 @@ const String = gdzig.builtin.String;
 const StringName = gdzig.builtin.StringName;
 const Variant = gdzig.builtin.Variant;
 const Object = gdzig.class.Object;
+
+const meta = @import("meta.zig");

--- a/gdzig_common/GeneralPurposeAllocator.zig
+++ b/gdzig_common/GeneralPurposeAllocator.zig
@@ -1,0 +1,68 @@
+//! A wrapper around multiple allocator implementations based on the build target.
+//!
+//! | Target                         | Implementation            |
+//! | ------------------------------ | ------------------------- |
+//! | Testing                        | `std.testing.allocator`   |
+//! | WebAssembly                    | `std.heap.WasmAllocator`  |
+//! | `.ReleaseSafe`/`.Debug`        | `std.heap.DebugAllocator` |
+//! | `.ReleaseFast`/`.ReleaseSmall` | Passthrough               |
+//!
+//! ## Usage
+//!
+//! ```zig
+//! var gpa: GeneralPurposeAllocator = .init(godot.engine_allocator);
+//! const allocator = gpa.allocator();
+//! ```
+//!
+
+const GeneralPurposeAllocator = @This();
+
+const Strategy = enum { testing, wasm, safe, fast };
+const strategy: Strategy = if (builtin.is_test)
+    .testing
+else if (builtin.target.cpu.arch.isWasm())
+    .wasm
+else switch (builtin.mode) {
+    .ReleaseSafe, .Debug => .safe,
+    .ReleaseFast, .ReleaseSmall => .fast,
+};
+
+impl: switch (strategy) {
+    .testing => *@TypeOf(std.testing.allocator_instance),
+    .wasm => WasmAllocator,
+    .safe => DebugAllocator(.{}),
+    .fast => Allocator,
+},
+
+pub fn init(backing_allocator: ?Allocator) GeneralPurposeAllocator {
+    return .{
+        .impl = switch (strategy) {
+            .testing => &std.testing.allocator_instance,
+            .wasm => .{},
+            .safe => .{
+                .backing_allocator = backing_allocator orelse std.heap.page_allocator,
+            },
+            .fast => backing_allocator orelse std.heap.page_allocator,
+        },
+    };
+}
+
+pub fn allocator(self: *GeneralPurposeAllocator) Allocator {
+    return switch (strategy) {
+        .fast => self.impl,
+        else => self.impl.allocator(),
+    };
+}
+
+pub fn deinit(self: *GeneralPurposeAllocator) std.heap.Check {
+    return switch (strategy) {
+        .safe => self.impl.deinit(),
+        else => .ok,
+    };
+}
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const DebugAllocator = std.heap.DebugAllocator;
+const WasmAllocator = std.heap.WasmAllocator;
+const builtin = @import("builtin");

--- a/gdzig_common/gdzig_common.zig
+++ b/gdzig_common/gdzig_common.zig
@@ -1,3 +1,5 @@
+pub const GeneralPurposeAllocator = @import("GeneralPurposeAllocator.zig");
+
 pub const godot_case = struct {
     pub const constant: Config = .constant;
     pub const func: Config = .snake;


### PR DESCRIPTION
this is in `gdzig_common` because it is for internal use only, and is not exported as a public API.

| Target                         | Implementation            |
| ------------------------------ | ------------------------- |
| Testing                        | `std.testing.allocator`   |
| WebAssembly                    | `std.heap.WasmAllocator`  |
| `.ReleaseSafe`/`.Debug`        | `std.heap.DebugAllocator` |
| `.ReleaseFast`/`.ReleaseSmall` | Passthrough               |

hopefully addresses @fig-eater's comment in #163 
