### PR TITLE
memory model documentation and fixes for variants, vararg and reference counting

### DIFF
--- a/docs/memory.md
+++ b/docs/memory.md
@@ -1,0 +1,129 @@
+# Memory
+
+gdzig bridges two memory models: Zig's explicit allocator-passing style and Godot's internal memory management. Understanding how they interact will help you avoid leaks and crashes.
+
+## Allocators
+
+Godot provides its own allocator through the GDExtension API. gdzig wraps this as `gdzig.engine_allocator`, which implements the standard `std.mem.Allocator` interface. You can use it anywhere you'd use a Zig allocator.
+
+The recommended setup is `std.heap.DebugAllocator` with `engine_allocator` as the backing allocator. This catches leaks and use-after-free in your Zig code, while still routing through Godot so its profiler can track total memory usage.
+
+## Godot Types
+
+Godot has two main kinds of types:
+
+- **Builtins**: Value types with known layout - either stack-allocated structs or reference-counted types on the heap.
+- **Classes**: Heap-allocated objects accessed by pointer. Engine classes are opaque; your extension classes are not.
+
+Each category has different memory management rules, covered in the sections below.
+
+## Builtin Types
+
+Builtins fall into two categories:
+
+**Value types** like `Vector2`, `Vector3`, `Color`, `Rect2`, etc. are plain structs. They live on the stack, copy by value, and need no cleanup.
+
+**Reference-counted value types** like `String`, `Array`, `Dictionary`, `Callable`, and `Signal` use copy-on-write semantics. When you assign or pass them, they share the underlying buffer until one copy is modified. From your perspective, they behave like copies - you can use them independently. Call `deinit()` when done to release your reference:
+
+```zig
+var arr = Array.init();
+defer arr.deinit();
+```
+
+### Variant
+
+`Variant` is a builtin that acts as Godot's dynamic type container, used extensively in the scripting API. It can hold:
+
+- Primitives: `nil`, `bool`, `int`, `float`
+- Math types: `Vector2`, `Vector2i`, `Vector3`, `Vector3i`, `Vector4`, `Vector4i`, `Rect2`, `Rect2i`, `Plane`, `Quaternion`, `Color`
+- Transforms: `Transform2d`, `Transform3d`, `Basis`, `Projection`, `Aabb`
+- Strings: `String`, `StringName`, `NodePath`
+- Collections: `Array`, `Dictionary`
+- Packed arrays: `PackedByteArray`, `PackedInt32Array`, `PackedInt64Array`, `PackedFloat32Array`, `PackedFloat64Array`, `PackedStringArray`, `PackedVector2Array`, `PackedVector3Array`, `PackedVector4Array`, `PackedColorArray`
+- References: `Rid`, `Object`, `Callable`, `Signal`
+
+Most types wrap into `Variant` cheaply. However, five types allocate from Godot's pool allocators when wrapped:
+
+- `Transform2d`
+- `Aabb`
+- `Basis`
+- `Transform3d`
+- `Projection`
+
+#### Always deinit `Variant`s
+
+When you receive a `Variant` (from `Object.call()`, for example), you **must** call `deinit()` when done:
+
+```zig
+var result = object.call(method, .{arg1, arg2});
+defer result.deinit();
+// use result...
+```
+
+## Classes
+
+Beyond value types and Variants, Godot has **classes** - heap-allocated objects accessed by pointer. All classes inherit from `Object`, with some inheriting from `RefCounted` (itself an `Object` subclass).
+
+**RefCounted** classes (and their descendants like `Resource`) use reference counting. You must manage this manually:
+
+```zig
+// When acquiring a reference
+_ = obj.reference();
+
+// When releasing
+if (obj.unreference()) obj.destroy();
+```
+
+**Non-RefCounted** classes (like `Node`) require manual destruction. Prefer `node.queueFree()` which defers destruction until safe. Use `node.destroy()` only when immediate destruction is required (e.g., in your extension class's destroy callback).
+
+### Extension Classes
+
+When you define your own extension class, there are two allocations necessary:
+
+1. **Engine class**: Allocated via Godot's allocator, holds the native Object data
+2. **Extension class**: Allocated via your allocator, holds your Zig struct
+
+Treat your extension class as owning the engine class. Create the engine class in your constructor (via `Base.init()`), link them (via `base.setInstance(self)`), and destroy it in your destructor (via `base.destroy()`). gdzig handles the coordination between the two allocators.
+
+```zig
+const Player = struct {
+    base: *Node2D,
+
+    pub fn create(allocator: *std.mem.Allocator) !*Player {
+        const self = try allocator.create(Player);
+        self.* = .{ .base = .init() };
+        self.base.setInstance(self);
+        return self;
+    }
+
+    pub fn destroy(self: *Player, allocator: *Allocator) void {
+        self.base.destroy();
+        allocator.destroy(self);
+    }
+};
+```
+
+Note that `Object.init()` is non-fallible (it will panic on failure), so no `errdefer` cleanup of `self` is necessary.
+
+## Method Calls
+
+gdzig generates two styles of methods for Godot's types:
+
+- **Fixed-arity methods** have a known number of arguments. These pass arguments directly by pointer with no Variant boxing - the fast path with no allocations.
+
+- **Vararg methods** like `Object.call()` accept any number of arguments by boxing them into Variants. The return value is always a `Variant` that you must `deinit()`.
+
+For vararg functions, gdzig provides two versions:
+
+- **Non-allocating** (`call`, `emit`, etc.): Compile error if you pass `Transform2d`, `Aabb`, `Basis`, `Transform3d`, or `Projection`. These would allocate when boxed into Variant, so they are not allowed.
+- **Allocating** (`callAlloc`, `emitAlloc`, etc.): Accepts those types, boxing them in a Variant internally.
+
+The non-allocating versions protect you from accidental leaks. If you need to pass one of those types, use the allocating version or wrap the value in a `Variant` and manage its lifetime yourself.
+
+## Common Gotchas
+
+**Leaking Variants**: Any `Variant` returned from a vararg call must be `deinit()`ed. The compiler can't catch this.
+
+**Pool-allocating types in varargs**: Using `Transform3d` etc. in `call()` or `emit()` is a compile error by design. Use the Alloc variants.
+
+**Storing RefCounted references**: Storing raw pointers to RefCounted objects won't prevent collection - you must call `reference()` to prevent the object from being freed.

--- a/example/src/SignalNode.zig
+++ b/example/src/SignalNode.zig
@@ -81,16 +81,16 @@ pub fn onSignal3(self: *Self) void {
 }
 
 pub fn emitSignal1(self: *Self) void {
-    self.base.emit(Signal1{
+    self.base.emit(Signal1, .{
         .name = .fromLatin1("test_signal_name"),
         .position = .initXYZ(123, 321, 333),
     }) catch {};
 }
 pub fn emitSignal2(self: *Self) void {
-    self.base.emit(Signal2{}) catch {};
+    self.base.emit(Signal2, .{}) catch {};
 }
 pub fn emitSignal3(self: *Self) void {
-    self.base.emit(Signal3{}) catch {};
+    self.base.emit(Signal3, .{}) catch {};
 }
 
 const std = @import("std");

--- a/gdzig/builtin/variant.zig
+++ b/gdzig/builtin/variant.zig
@@ -19,12 +19,29 @@ pub const Variant = extern struct {
 
     pub fn init(comptime T: type, value: T) Variant {
         const tag = comptime Tag.forType(T);
-        const variantFromType = getVariantFromTypeConstructor(tag);
 
-        var result: Variant = undefined;
         if (tag == .object) {
-            variantFromType(@ptrCast(&result), @ptrCast(@constCast(&class.upcast(*Object, value))));
-        } else switch (@typeInfo(T)) {
+            // For RefCounted objects, manually construct the Variant and call reference()
+            // to share ownership. We bypass variantFromType because it uses init_ref()
+            // which only works correctly for first-time ownership transfer.
+            if (comptime class.isRefCountedPtr(T)) {
+                _ = RefCounted.upcast(value).reference();
+            }
+            const obj = Object.upcast(value);
+            return .{
+                .tag = .object,
+                .data = .{
+                    .object = .{
+                        .id = @enumFromInt(obj.getInstanceId()),
+                        .object = obj,
+                    },
+                },
+            };
+        }
+
+        const variantFromType = getVariantFromTypeConstructor(tag);
+        var result: Variant = undefined;
+        switch (@typeInfo(T)) {
             .pointer => variantFromType(@ptrCast(&result), @ptrCast(@constCast(value))),
             else => {
                 var v: T = value;
@@ -532,6 +549,20 @@ pub const Variant = extern struct {
         pub fn canConvertStrict(from: Tag, to: Tag) bool {
             return raw.variantCanConvertStrict(@intFromEnum(from), @intFromEnum(to)) != 0;
         }
+
+        /// Returns true if this variant type allocates from Godot's pool allocators.
+        /// These types need explicit cleanup when wrapped in a Variant.
+        pub fn allocates(self: Tag) bool {
+            return switch (self) {
+                .transform2d, .aabb, .basis, .transform3d, .projection => true,
+                else => false,
+            };
+        }
+
+        /// Returns true if wrapping the given type in a Variant would allocate from Godot's pool allocators.
+        pub fn allocatesForType(comptime T: type) bool {
+            return forType(T).allocates();
+        }
     };
 
     pub const Data = extern union {
@@ -747,6 +778,7 @@ const Vector3i = gdzig.builtin.Vector3i;
 const Vector4 = gdzig.builtin.Vector4;
 const Vector4i = gdzig.builtin.Vector4i;
 const Object = gdzig.class.Object;
+const RefCounted = gdzig.class.RefCounted;
 const class = gdzig.class;
 
 const precision = @import("build_options").precision;

--- a/gdzig/class/Object.mixin.zig
+++ b/gdzig/class/Object.mixin.zig
@@ -110,15 +110,33 @@ pub fn disconnect(self: *Self, comptime S: type, callable: Callable) void {
     self.disconnectRaw(signal_name, callable);
 }
 
-/// Emits a signal.
-pub fn emit(self: *Self, signal: anytype) EmitError!void {
-    const S = @TypeOf(signal);
-    const signal_name: StringName = .fromComptimeLatin1(casez.comptimeConvert(godot_case.signal, meta.typeShortName(S)));
-    const fields = @typeInfo(S).@"struct".fields;
-    var args: std.meta.Tuple(&typeInfoToTypes(fields)) = undefined;
+/// Emits a signal. Guarantees no allocations when calling across the FFI. Passing Transform2D, AABB, Basis, Transform3D, or Projection is a compile error; use the Alloc variant.
+pub fn emit(self: *Self, comptime Signal: type, signal: AssertNonAllocating(Signal)) EmitError!void {
+    const signal_name: StringName = .fromComptimeLatin1(casez.comptimeConvert(godot_case.signal, meta.typeShortName(Signal)));
+    const fields = @typeInfo(Signal).@"struct".fields;
+    var args: [fields.len]Variant = undefined;
     inline for (fields, 0..) |field, i| {
-        args[i] = @field(signal, field.name);
+        args[i] = Variant.init(field.type, @field(signal, field.name));
     }
+    // No defer needed - non-allocating types don't need cleanup
+    return emitImpl(self, signal_name, args);
+}
+
+/// Emits a signal. Will necessarily allocate when calling across the FFI with Transform2d, Aabb, Basis, Transform3d, or Projection.
+pub fn emitAlloc(self: *Self, comptime Signal: type, signal: Signal) EmitError!void {
+    const signal_name: StringName = .fromComptimeLatin1(casez.comptimeConvert(godot_case.signal, meta.typeShortName(Signal)));
+    const fields = @typeInfo(Signal).@"struct".fields;
+    var args: [fields.len]Variant = undefined;
+    inline for (fields, 0..) |field, i| {
+        args[i] = Variant.init(field.type, @field(signal, field.name));
+    }
+    defer inline for (&args, fields) |*arg, field| {
+        if (allocatesAsVariant(field.type)) arg.deinit();
+    };
+    return emitImpl(self, signal_name, args);
+}
+
+fn emitImpl(self: *Self, signal_name: StringName, args: anytype) EmitError!void {
     switch (self.emitRaw(signal_name, args)) {
         .ok => {},
         .err_unavailable => {
@@ -132,13 +150,19 @@ pub fn emit(self: *Self, signal: anytype) EmitError!void {
     }
 }
 
-fn typeInfoToTypes(comptime fields: []const std.builtin.Type.StructField) [fields.len]type {
-    var types: [fields.len]type = undefined;
-    for (fields, 0..) |field, i| {
-        types[i] = field.type;
+/// Returns Signal if no fields allocate, otherwise generates a compile error.
+fn AssertNonAllocating(comptime Signal: type) type {
+    const fields = @typeInfo(Signal).@"struct".fields;
+    inline for (fields) |field| {
+        if (allocatesAsVariant(field.type)) {
+            @compileError("Signal field '" ++ field.name ++ "' has type " ++ @typeName(field.type) ++
+                " which allocates when wrapped in Variant. Use emitAlloc instead.");
+        }
     }
-    return types;
+    return Signal;
 }
+
+const allocatesAsVariant = Variant.Tag.allocatesForType;
 
 const casez = @import("casez");
 const common = @import("common");

--- a/gdzig/gdzig.zig
+++ b/gdzig/gdzig.zig
@@ -20,6 +20,7 @@ pub const engine_allocator = @import("heap.zig").engine_allocator;
 pub const general = @import("general.zig");
 pub const global = @import("global.zig");
 pub const math = @import("math.zig");
+
 pub const random = @import("random.zig");
 const register = @import("register.zig");
 pub const registerClass = register.registerClass;

--- a/gdzig_bindgen/Context/type.zig
+++ b/gdzig_bindgen/Context/type.zig
@@ -350,6 +350,25 @@ pub const Type = union(enum) {
             else => null,
         };
     }
+
+    /// Returns true if wrapping this type in a Variant would allocate from Godot's pool allocators.
+    /// These types need explicit cleanup when wrapped: Transform2D, AABB, Basis, Transform3D, Projection.
+    /// Note: This must stay in sync with Variant.Tag.allocates() in the runtime.
+    pub fn allocatesAsVariant(self: Type, ctx: *const Context) bool {
+        _ = ctx;
+        const name = switch (self) {
+            .basic => |n| n,
+            else => return false,
+        };
+        return std.mem.eql(u8, name, "Transform2D") or
+            std.mem.eql(u8, name, "Transform2d") or
+            std.mem.eql(u8, name, "AABB") or
+            std.mem.eql(u8, name, "Aabb") or
+            std.mem.eql(u8, name, "Basis") or
+            std.mem.eql(u8, name, "Transform3D") or
+            std.mem.eql(u8, name, "Transform3d") or
+            std.mem.eql(u8, name, "Projection");
+    }
 };
 
 const std = @import("std");

--- a/gdzig_bindgen/codegen.zig
+++ b/gdzig_bindgen/codegen.zig
@@ -386,6 +386,12 @@ fn writeClass(w: *CodeWriter, class: *const Context.Class, ctx: *const Context) 
         if (function.mode != .final) continue;
         try writeClassFunction(w, class, function, ctx);
         try w.writeLine("");
+
+        // Write allocating wrapper for vararg functions
+        if (function.is_vararg) {
+            try writeFunctionAlloc(w, function, class, ctx);
+            try w.writeLine("");
+        }
     }
 
     // TODO: write properties and signals
@@ -450,6 +456,12 @@ fn writeSignal(w: *CodeWriter, signal: *const Context.Signal, class: *const Cont
 }
 
 fn writeClassFunction(w: *CodeWriter, class: *const Context.Class, function: *const Context.Function, ctx: *const Context) !void {
+    // For vararg functions, generate a thin wrapper that does comptime check + delegates to Alloc version
+    if (function.is_vararg) {
+        try writeClassFunctionVarargWrapper(w, class, function, ctx);
+        return;
+    }
+
     try writeFunctionHeader(w, function, class, ctx);
 
     if (class.is_singleton) {
@@ -458,10 +470,6 @@ fn writeClassFunction(w: *CodeWriter, class: *const Context.Class, function: *co
             \\    instance = @ptrCast(raw.globalGetSingleton(@ptrCast(&StringName.fromComptimeLatin1(self_name))).?);
             \\}
         );
-    }
-
-    if (function.is_vararg) {
-        try w.writeLine("var err: c.GDExtensionCallError = undefined;");
     }
 
     try w.printLine(
@@ -475,30 +483,260 @@ fn writeClassFunction(w: *CodeWriter, class: *const Context.Class, function: *co
         function.hash.?,
     });
 
-    if (function.is_vararg) {
-        try w.print("raw.objectMethodBindCall({0s}_ptr, ", .{function.name});
-        try writeClassFunctionObjectPtr(w, class, function, ctx);
-        try w.printLine(", @ptrCast(@alignCast(&args[0])), args.len, {s}, &err);", .{
-            if (function.return_type != .void)
-                "@ptrCast(&result)"
-            else
-                "null",
-        });
-    } else {
-        try w.print("raw.objectMethodBindPtrcall({0s}_ptr, ", .{function.name});
-        try writeClassFunctionObjectPtr(w, class, function, ctx);
-        try w.printLine(", @ptrCast(&args), {s});", .{
-            if (function.return_type != .void)
-                "@ptrCast(&result)"
-            else
-                "null",
-        });
-    }
+    try w.print("raw.objectMethodBindPtrcall({0s}_ptr, ", .{function.name});
+    try writeClassFunctionObjectPtr(w, class, function, ctx);
+    try w.printLine(", @ptrCast(&args), {s});", .{
+        if (function.return_type != .void)
+            "@ptrCast(&result)"
+        else
+            "null",
+    });
 
     try writeFunctionFooter(w, function, class, ctx);
     try w.printLine(
         \\var {0s}_ptr: c.GDExtensionMethodBindPtr = null;
     , .{function.name});
+}
+
+/// Writes a thin vararg wrapper that does comptime check and delegates to the Alloc version.
+fn writeClassFunctionVarargWrapper(w: *CodeWriter, class: *const Context.Class, function: *const Context.Function, ctx: *const Context) !void {
+    try w.writeLine(
+        \\/// Guarantees no allocations when calling across the FFI. Passing Transform2d, Aabb, Basis, Transform3d, or Projection is a compile error; use the Alloc variant.
+        \\///
+    );
+    try writeDocBlock(w, function.doc);
+
+    // Function signature
+    if (std.zig.Token.keywords.has(function.name)) {
+        try w.print("pub fn @\"{s}\"(", .{function.name});
+    } else {
+        try w.print("pub fn {s}(", .{function.name});
+    }
+
+    var is_first = true;
+    const has_self = switch (function.self) {
+        .static, .singleton => false,
+        else => true,
+    };
+
+    if (has_self) {
+        try w.print("self: *{s}", .{class.name});
+        is_first = false;
+    }
+
+    for (function.parameters.values()) |param| {
+        if (!is_first) try w.writeAll(", ");
+        try w.print("{s}: ", .{param.name});
+        try writeTypeAtParameter(w, &param.type, class, ctx);
+        is_first = false;
+    }
+
+    if (!is_first) try w.writeAll(", ");
+    try w.writeAll("@\"...\": anytype) ");
+    try writeTypeAtReturn(w, &function.return_type, class, ctx);
+    try w.writeLine(" {");
+    w.indent += 1;
+
+    // Comptime check - skip Variant type (already a Variant, no wrapping needed)
+    try w.printLine(
+        \\inline for (0..@"...".len) |_i| {{
+        \\    if (@TypeOf(@"..."[_i]) != Variant and comptime Variant.Tag.allocatesForType(@TypeOf(@"..."[_i]))) {{
+        \\        @compileError(@typeName(@TypeOf(@"..."[_i])) ++ " allocates as Variant; use {s}Alloc() or pass a Variant instead.");
+        \\    }}
+        \\}}
+    , .{function.name});
+
+    // Delegate to Alloc version
+    if (function.return_type != .void) {
+        try w.writeAll("return ");
+    }
+
+    if (has_self) {
+        try w.print("self.{s}Alloc(", .{function.name});
+    } else {
+        try w.print("{s}Alloc(", .{function.name});
+    }
+
+    is_first = true;
+    for (function.parameters.values()) |param| {
+        if (!is_first) try w.writeAll(", ");
+        try w.print("{s}", .{param.name});
+        is_first = false;
+    }
+
+    if (!is_first) try w.writeAll(", ");
+    try w.writeLine("@\"...\");");
+
+    w.indent -= 1;
+    try w.writeLine("}");
+}
+
+/// Writes the allocating version of a vararg function that does the actual FFI call.
+fn writeFunctionAlloc(w: *CodeWriter, function: *const Context.Function, class: ?*const Context.Class, ctx: *const Context) !void {
+    try w.writeLine(
+        \\/// Will necessarily allocate when calling across the FFI with Transform2d, Aabb, Basis, Transform3d, or Projection.
+        \\///
+    );
+    try writeDocBlock(w, function.doc);
+
+    // Declaration with Alloc suffix
+    if (std.zig.Token.keywords.has(function.name)) {
+        try w.print("pub fn @\"{s}Alloc\"(", .{function.name});
+    } else {
+        try w.print("pub fn {s}Alloc(", .{function.name});
+    }
+
+    var is_first = true;
+
+    // Self parameter
+    switch (function.self) {
+        .static, .singleton => {},
+        .constant => |api_name| {
+            const name = if (ctx.classes.get(api_name)) |c| c.name else if (ctx.builtins.get(api_name)) |b| b.name else api_name;
+            try w.print("self: *const {0s}", .{name});
+            is_first = false;
+        },
+        .mutable => |api_name| {
+            const name = if (ctx.classes.get(api_name)) |c| c.name else if (ctx.builtins.get(api_name)) |b| b.name else api_name;
+            try w.print("self: *{0s}", .{name});
+            is_first = false;
+        },
+        .value => |api_name| {
+            const name = if (ctx.classes.get(api_name)) |c| c.name else if (ctx.builtins.get(api_name)) |b| b.name else api_name;
+            try w.print("self: {0s}", .{name});
+            is_first = false;
+        },
+    }
+
+    // Positional parameters
+    for (function.parameters.values()) |param| {
+        if (!is_first) {
+            try w.writeAll(", ");
+        }
+        try w.print("{s}: ", .{param.name});
+        try writeTypeAtParameter(w, &param.type, class, ctx);
+        is_first = false;
+    }
+
+    // Variadic parameters as anytype
+    if (!is_first) {
+        try w.writeAll(", ");
+    }
+    try w.writeAll("@\"...\": anytype");
+
+    // Return type
+    try w.writeAll(") ");
+    try writeTypeAtReturn(w, &function.return_type, class, ctx);
+    try w.writeLine(" {");
+    w.indent += 1;
+
+    const param_count = function.parameters.count();
+
+    // Build pointer array to stack-temporary Variants
+    try w.printLine("var args: [{d} + @\"...\".len]*Variant = undefined;", .{param_count});
+
+    // Fixed parameters - wrap in Variant (unless already Variant), defer deinit immediately
+    for (function.parameters.values(), 0..) |param, i| {
+        if (param.type == .variant) {
+            try w.printLine("args[{d}] = @constCast(&{s});", .{ i, param.name });
+        } else {
+            try w.print("args[{d}] = @constCast(&Variant.init(", .{i});
+            try writeTypeAtParameter(w, &param.type, class, ctx);
+            try w.printLine(", {s}));", .{param.name});
+            try w.printLine("defer args[{d}].deinit();", .{i});
+        }
+    }
+
+    // Varargs - check if already a Variant before wrapping
+    try w.printLine("inline for (0..@\"...\".len, {d}..args.len) |i, j| {{", .{param_count});
+    w.indent += 1;
+    try w.writeLine("if (@TypeOf(@\"...\"[i]) == Variant) {");
+    w.indent += 1;
+    try w.writeLine("args[j] = @constCast(&@\"...\"[i]);");
+    w.indent -= 1;
+    try w.writeLine("} else {");
+    w.indent += 1;
+    try w.writeLine("args[j] = @constCast(&Variant.init(@TypeOf(@\"...\"[i]), @\"...\"[i]));");
+    w.indent -= 1;
+    try w.writeLine("}");
+    w.indent -= 1;
+    try w.writeLine("}");
+
+    // Defer deinit for varargs - only if we created the Variant
+    try w.printLine("defer inline for (0..@\"...\".len, {d}..args.len) |i, j| {{", .{param_count});
+    w.indent += 1;
+    try w.writeLine("if (@TypeOf(@\"...\"[i]) != Variant) {");
+    w.indent += 1;
+    try w.writeLine("args[j].deinit();");
+    w.indent -= 1;
+    try w.writeLine("}");
+    w.indent -= 1;
+    try w.writeLine("};");
+
+    // Return variable
+    try w.writeLine("var result: Variant = .nil;");
+
+    // Method bind lookup and call
+    if (class) |cls| {
+        try w.writeLine("var err: c.GDExtensionCallError = undefined;");
+        // Class method
+        if (cls.is_singleton) {
+            try w.writeLine("if (instance == null) {");
+            w.indent += 1;
+            try w.writeLine("instance = @ptrCast(raw.globalGetSingleton(@ptrCast(&StringName.fromComptimeLatin1(self_name))).?);");
+            w.indent -= 1;
+            try w.writeLine("}");
+        }
+
+        try w.printLine("if ({0s}Alloc_ptr == null) {{", .{function.name});
+        w.indent += 1;
+        try w.printLine("{0s}Alloc_ptr = raw.classdbGetMethodBind(@ptrCast(&StringName.fromComptimeLatin1(\"{1s}\")), @ptrCast(&StringName.fromComptimeLatin1(\"{2s}\")), {3d});", .{
+            function.name,
+            function.base.?,
+            function.name_api,
+            function.hash.?,
+        });
+        w.indent -= 1;
+        try w.writeLine("}");
+
+        try w.print("raw.objectMethodBindCall({0s}Alloc_ptr, ", .{function.name});
+        try writeClassFunctionObjectPtr(w, cls, function, ctx);
+        try w.writeLine(", @ptrCast(@alignCast(&args[0])), @intCast(args.len), @ptrCast(&result), &err);");
+    } else {
+        // Utility function
+        try w.printLine("if ({0s}Alloc_ptr == null) {{", .{function.name});
+        w.indent += 1;
+        try w.printLine("{0s}Alloc_ptr = raw.variantGetPtrUtilityFunction(@ptrCast(@constCast(&StringName.fromComptimeLatin1(\"{1s}\"))), {2d});", .{
+            function.name,
+            function.name_api,
+            function.hash.?,
+        });
+        w.indent -= 1;
+        try w.writeLine("}");
+        try w.printLine("{0s}Alloc_ptr.?(@ptrCast(&result), @ptrCast(&args), @intCast(args.len));", .{function.name});
+    }
+
+    // Return
+    switch (function.return_type) {
+        .class => try w.writeLine("return @ptrCast(result);"),
+        .variant => try w.writeLine("return result;"),
+        .void => {},
+        else => {
+            try w.writeAll("return result.as(");
+            try writeTypeAtReturn(w, &function.return_type, class, ctx);
+            try w.writeLine(").?;");
+        },
+    }
+
+    w.indent -= 1;
+    try w.writeLine("}");
+
+    // Method bind pointer storage
+    if (class != null) {
+        try w.printLine("var {0s}Alloc_ptr: c.GDExtensionMethodBindPtr = null;", .{function.name});
+    } else {
+        try w.printLine("var {0s}Alloc_ptr: c.GDExtensionPtrUtilityFunction = null;", .{function.name});
+    }
 }
 
 fn writeClassFunctionObjectPtr(w: *CodeWriter, class: *const Context.Class, function: *const Context.Function, ctx: *const Context) !void {
@@ -685,6 +923,12 @@ fn writeFlag(w: *CodeWriter, flag: *const Context.Flag, ctx: *const Context) !vo
 }
 
 fn writeFunctionHeader(w: *CodeWriter, function: *const Context.Function, class: ?*const Context.Class, ctx: *const Context) !void {
+    if (function.is_vararg) {
+        try w.writeLine(
+            \\/// Guarantees no allocations when calling across the FFI. Passing Transform2d, Aabb, Basis, Transform3d, or Projection is a compile error; use the Alloc variant.
+            \\///
+        );
+    }
     try writeDocBlock(w, function.doc);
 
     // Declaration
@@ -729,7 +973,12 @@ fn writeFunctionHeader(w: *CodeWriter, function: *const Context.Function, class:
             try w.writeAll(", ");
         }
         try w.print("{s}: ", .{param.name});
-        try writeTypeAtParameter(w, &param.type, class, ctx);
+        // For vararg functions, allocating types are passed as Variant
+        if (function.is_vararg and param.type.allocatesAsVariant(ctx)) {
+            try w.writeAll("Variant");
+        } else {
+            try writeTypeAtParameter(w, &param.type, class, ctx);
+        }
         is_first = false;
     }
 
@@ -738,7 +987,7 @@ fn writeFunctionHeader(w: *CodeWriter, function: *const Context.Function, class:
         if (!is_first) {
             try w.writeAll(", ");
         }
-        try w.print("@\"...\": anytype", .{});
+        try w.writeAll("@\"...\": anytype");
         is_first = false;
     }
 
@@ -812,30 +1061,56 @@ fn writeFunctionHeader(w: *CodeWriter, function: *const Context.Function, class:
         }
     }
 
-    // Variadic argument slice variable
+    // Variadic argument handling
     if (function.is_vararg and function.operator_name == null) {
-        try w.printLine("var args: [@\"...\".len + {d}]c.GDExtensionConstTypePtr = undefined;", .{function.parameters.count()});
+        const param_count = function.parameters.count();
+
+        // Comptime verification that vararg types don't allocate
+        try w.printLine(
+            \\inline for (0..@"...".len) |_i| {{
+            \\    if (comptime Variant.Tag.allocatesForType(@TypeOf(@"..."[_i]))) {{
+            \\        @compileError(@typeName(@TypeOf(@"..."[_i])) ++ " allocates as Variant; use {s}Alloc() or pass a Variant instead.");
+            \\    }}
+            \\}}
+        , .{function.name});
+
+        // Build varargs array
+        try w.writeLine("var _varargs: [@\"...\".len]Variant = undefined;");
+        try w.writeLine("inline for (0..@\"...\".len) |_i| _varargs[_i] = Variant.init(@TypeOf(@\"...\"[_i]), @\"...\"[_i]);");
+        try w.writeLine("defer for (&_varargs) |*v| v.deinit();");
+
+        try w.printLine("var args: [{d} + @\"...\".len]c.GDExtensionConstTypePtr = undefined;", .{param_count});
+
         for (function.parameters.values()[0..opt], 0..) |param, i| {
-            try w.print("args[{d}] = &Variant.init(", .{i});
-            try writeTypeAtParameter(w, &param.type, class, ctx);
-            try w.printLine(", {s});", .{param.name});
-        }
-        for (function.parameters.values()[opt..], opt..) |param, i| {
-            if (param.needsRuntimeInit(ctx)) {
-                try w.print("args[{d}] = &Variant.init(", .{i});
-                try writeTypeAtParameter(w, &param.type, class, ctx);
-                try w.printLine(", actual_{s});", .{param.name});
+            if (param.type == .variant or param.type.allocatesAsVariant(ctx)) {
+                try w.printLine("args[{d}] = @ptrCast(&{s});", .{ i, param.name });
             } else {
-                try w.print("args[{d}] = &Variant.init(", .{i});
+                try w.print("args[{d}] = @ptrCast(&Variant.init(", .{i});
                 try writeTypeAtParameter(w, &param.type, class, ctx);
-                try w.printLine(", opt.{s});", .{param.name});
+                try w.printLine(", {s}));", .{param.name});
             }
         }
-        try w.printLine(
-            \\inline for (0..@"...".len) |i| {{
-            \\    args[{d} + i] = &Variant.init(@TypeOf(@"..."[i]), @"..."[i]);
-            \\}}
-        , .{function.parameters.count()});
+        for (function.parameters.values()[opt..], opt..) |param, i| {
+            if (param.type == .variant or param.type.allocatesAsVariant(ctx)) {
+                if (param.needsRuntimeInit(ctx)) {
+                    try w.printLine("args[{d}] = @ptrCast(&actual_{s});", .{ i, param.name });
+                } else {
+                    try w.printLine("args[{d}] = @ptrCast(&opt.{s});", .{ i, param.name });
+                }
+            } else {
+                if (param.needsRuntimeInit(ctx)) {
+                    try w.print("args[{d}] = @ptrCast(&Variant.init(", .{i});
+                    try writeTypeAtParameter(w, &param.type, class, ctx);
+                    try w.printLine(", actual_{s}));", .{param.name});
+                } else {
+                    try w.print("args[{d}] = @ptrCast(&Variant.init(", .{i});
+                    try writeTypeAtParameter(w, &param.type, class, ctx);
+                    try w.printLine(", opt.{s}));", .{param.name});
+                }
+            }
+        }
+
+        try w.printLine("inline for (0..@\"...\".len) |_i| args[{d} + _i] = @ptrCast(&_varargs[_i]);", .{param_count});
     }
 
     // Return variable
@@ -1187,18 +1462,29 @@ fn writeModule(w: *CodeWriter, module: *const Context.Module, ctx: *const Contex
         if (function.skip) continue;
 
         try writeModuleFunction(w, function, ctx);
+
+        // Write allocating wrapper for vararg functions
+        if (function.is_vararg) {
+            try writeFunctionAlloc(w, function, null, ctx);
+        }
     }
     try writeImports(w, &module.imports, null, ctx);
 }
 
 fn writeModuleFunction(w: *CodeWriter, function: *const Context.Function, ctx: *const Context) !void {
+    // For vararg functions, generate a thin wrapper that does comptime check + delegates to Alloc version
+    if (function.is_vararg) {
+        try writeModuleFunctionVarargWrapper(w, function, ctx);
+        return;
+    }
+
     try writeFunctionHeader(w, function, null, ctx);
 
     try w.printLine(
         \\if ({0s}_ptr == null) {{
         \\    {0s}_ptr = raw.variantGetPtrUtilityFunction(@ptrCast(@constCast(&StringName.fromComptimeLatin1("{1s}"))), {2d});
         \\}}
-        \\{0s}_ptr.?({3s}, @ptrCast(&args), args.len);
+        \\{0s}_ptr.?({3s}, @ptrCast(&args), @intCast(args.len));
     , .{
         function.name,
         function.name_api,
@@ -1210,6 +1496,65 @@ fn writeModuleFunction(w: *CodeWriter, function: *const Context.Function, ctx: *
         \\var {0s}_ptr: c.GDExtensionPtrUtilityFunction = null;
         \\
     , .{function.name});
+}
+
+/// Writes a thin vararg wrapper for a module function that does comptime check and delegates to the Alloc version.
+fn writeModuleFunctionVarargWrapper(w: *CodeWriter, function: *const Context.Function, ctx: *const Context) !void {
+    try w.writeLine(
+        \\/// Guarantees no allocations when calling across the FFI. Passing Transform2d, Aabb, Basis, Transform3d, or Projection is a compile error; use the Alloc variant.
+        \\///
+    );
+    try writeDocBlock(w, function.doc);
+
+    // Function signature
+    if (std.zig.Token.keywords.has(function.name)) {
+        try w.print("pub fn @\"{s}\"(", .{function.name});
+    } else {
+        try w.print("pub fn {s}(", .{function.name});
+    }
+
+    var is_first = true;
+    for (function.parameters.values()) |param| {
+        if (!is_first) try w.writeAll(", ");
+        try w.print("{s}: ", .{param.name});
+        try writeTypeAtParameter(w, &param.type, null, ctx);
+        is_first = false;
+    }
+
+    if (!is_first) try w.writeAll(", ");
+    try w.writeAll("@\"...\": anytype) ");
+    try writeTypeAtReturn(w, &function.return_type, null, ctx);
+    try w.writeLine(" {");
+    w.indent += 1;
+
+    // Comptime check - skip Variant type (already a Variant, no wrapping needed)
+    try w.printLine(
+        \\inline for (0..@"...".len) |_i| {{
+        \\    if (@TypeOf(@"..."[_i]) != Variant and comptime Variant.Tag.allocatesForType(@TypeOf(@"..."[_i]))) {{
+        \\        @compileError(@typeName(@TypeOf(@"..."[_i])) ++ " allocates as Variant; use {s}Alloc() or pass a Variant instead.");
+        \\    }}
+        \\}}
+    , .{function.name});
+
+    // Delegate to Alloc version
+    if (function.return_type != .void) {
+        try w.writeAll("return ");
+    }
+
+    try w.print("{s}Alloc(", .{function.name});
+
+    is_first = true;
+    for (function.parameters.values()) |param| {
+        if (!is_first) try w.writeAll(", ");
+        try w.print("{s}", .{param.name});
+        is_first = false;
+    }
+
+    if (!is_first) try w.writeAll(", ");
+    try w.writeLine("@\"...\");");
+
+    w.indent -= 1;
+    try w.writeLine("}");
 }
 
 /// Converts a possibly qualified type name (e.g., "AStarGrid2D.CellShape") to use converted class prefixes.

--- a/gdzig_test/gdzig_test.zig
+++ b/gdzig_test/gdzig_test.zig
@@ -55,7 +55,7 @@ fn fail(err: anyerror) noreturn {
 pub fn expectCall(object: anytype, comptime name: [:0]const u8, args: anytype, expected: anytype) !void {
     const method: StringName = .fromComptimeLatin1(name);
 
-    var result = Object.call(.upcast(object), method, args);
+    var result = Object.callAlloc(.upcast(object), method, args);
     defer result.deinit();
 
     const val = result.as(@TypeOf(expected)) orelse return error.InvalidResult;

--- a/tests/interop/test.zig
+++ b/tests/interop/test.zig
@@ -129,7 +129,7 @@ pub const ZigObject = struct {
 
     /// Emit a signal for GDScript to receive
     pub fn emitZigSignal(self: *ZigObject, value: i64) void {
-        self.base.emit(ZigSignal{ .value = value }) catch {};
+        self.base.emit(ZigSignal, .{ .value = value }) catch {};
     }
 };
 

--- a/tests/leaks/test.zig
+++ b/tests/leaks/test.zig
@@ -1,0 +1,26 @@
+pub fn run() !void {
+    const object = RefCounted.init();
+    try testing.expectEqual(@as(i32, 1), object.getReferenceCount());
+    const variant = Variant.init(*RefCounted, object);
+    try testing.expectEqual(@as(i32, 2), object.getReferenceCount());
+
+    for (0..10) |_| {
+        general.print(variant, .{ object, variant });
+    }
+
+    try testing.expectEqual(@as(i32, 2), object.getReferenceCount());
+    variant.deinit();
+    try testing.expectEqual(@as(i32, 1), object.getReferenceCount());
+    try testing.expect(object.unreference());
+    object.destroy();
+}
+
+const std = @import("std");
+const assert = std.debug.assert;
+
+const godot = @import("gdzig");
+const general = godot.general;
+const RefCounted = godot.class.RefCounted;
+const StringName = godot.builtin.StringName;
+const Variant = godot.builtin.Variant;
+const testing = @import("gdzig_test");

--- a/tests/signals/test.zig
+++ b/tests/signals/test.zig
@@ -19,14 +19,14 @@ pub fn run() !void {
     try testing.expectEqual(0, receiver.count);
     try testing.expectEqual(0, receiver.value);
 
-    try emitter.base.emit(TestSignal{ .value = 42 });
+    try emitter.base.emit(TestSignal, .{ .value = 42 });
 
     try testing.expectEqual(1, receiver.count);
     try testing.expectEqual(42, receiver.value);
 
     emitter.base.disconnect(TestSignal, callable);
 
-    try emitter.base.emit(TestSignal{ .value = 99 });
+    try emitter.base.emit(TestSignal, .{ .value = 99 });
 
     try testing.expectEqual(1, receiver.count);
     try testing.expectEqual(42, receiver.value);


### PR DESCRIPTION
## Variants

Variants now properly increment refcount when wrapping RefCounted objects, matching the copy semantics of String/Array/Dictionary

## Vararg functions

Varargs functions now generate two versions: allocating and non-allocating. For example, the `call` and `callAlloc` functions, or `print` and `printAlloc`.

The difference between these two is that `print` has a comptime guarantee that it _will not allocate_ when wrapping your arguments in `Variant`s. It then just calls `printAlloc`. This compile time guarantee comes with the drawback of limiting the types of values you can use.

We also properly handle `Variant`s passed as varargs and don't try to double wrap them in another `Variant`.

## New `leaks` integration test

Added a new test that verifies refcount stays correct when passing `RefCounted` objects around through vararg functions.

## Memory documentation

Added a first pass at documenting the memory model.

fixes #138 