### PR TITLE
Add missing required build paths to build.zig.zon

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -39,8 +39,12 @@
         "gdzig_common",
         "gdzig_bindgen",
         "gdzig_test",
-        "tests",
+        "test",
+        "build",
         "build.zig",
         "build.zig.zon",
+        "example",
+        "pkg",
+        "src",
     },
 }


### PR DESCRIPTION
Adds `build/`, `example/`, `pkg/`, `src/`, and fixes the `test/` directory in the build.zig.zon. Without this, fetching as a dependency miss required source files.