### PR TITLE
fix: ignore gdextension deinitialize calls lower than the min init level

### DIFF
--- a/src/extension/entrypoint.zig
+++ b/src/extension/entrypoint.zig
@@ -39,6 +39,8 @@ fn enter(_: ?*anyopaque, level: gdzig.c.GDExtensionInitializationLevel) callconv
 }
 
 fn exit(_: ?*anyopaque, level: gdzig.c.GDExtensionInitializationLevel) callconv(.c) void {
+    if (level < @intFromEnum(options.minimum_initialization_level)) return;
+
     registry.exit(@enumFromInt(level));
     if (level == @intFromEnum(options.minimum_initialization_level)) {
         gdzig.extension.PropertyListInstanceBinding.cleanup();


### PR DESCRIPTION
I was encountering a segfault when closing a game using gdzig. Using a debugger, I narrowed it down to this spot. Where if exit was called for levels < minimum_initialization_level, `registry` would have already been deinitalized. I've updated it to ignore all levels below the minimum.