### PR TITLE
Fix godot 4.6 builds.

### DIFF
--- a/pkg/bindgen/Context/Function.zig
+++ b/pkg/bindgen/Context/Function.zig
@@ -94,6 +94,11 @@ const operator_enum_names = StaticStringMap([]const u8).initComptime(.{
     .{ "in", "in" },
 });
 
+/// Set of type meta values to ignore.
+const ignored_meta_values = std.StaticStringMap(void).initComptime(.{
+    .{ "required", {} }, // Introduced in 4.6. ignore for now
+});
+
 pub fn fromBuiltinOperator(allocator: Allocator, builtin_name: []const u8, api: GodotApi.Builtin.Operator, ctx: *const Context) !Function {
     var self: Function = .{};
 
@@ -321,12 +326,15 @@ pub fn fromClass(allocator: Allocator, class_name: []const u8, has_singleton: bo
     self.is_vararg = api.is_vararg;
 
     for (api.arguments orelse &.{}) |arg| {
+        const is_meta = arg.meta.len > 0 and !ignored_meta_values.has(arg.meta);
+        const arg_type = if (is_meta) arg.meta else arg.type;
+
         const parameter: Parameter = if (arg.default_value.len > 0)
             try .fromNameTypeDefault(
                 allocator,
                 arg.name,
-                if (arg.meta.len > 0) arg.meta else arg.type,
-                arg.meta.len > 0,
+                arg_type,
+                is_meta,
                 arg.default_value,
                 ctx,
             )
@@ -334,23 +342,23 @@ pub fn fromClass(allocator: Allocator, class_name: []const u8, has_singleton: bo
             try .fromNameType(
                 allocator,
                 arg.name,
-                if (arg.meta.len > 0) arg.meta else arg.type,
-                arg.meta.len > 0,
+                arg_type,
+                is_meta,
                 ctx,
                 .{},
             );
         try self.parameters.put(allocator, arg.name, parameter);
     }
 
-    self.return_type = if (api.return_value) |rv|
-        try .from(
+    self.return_type = if (api.return_value) |rv| blk: {
+        const is_meta = rv.meta.len > 0 and !ignored_meta_values.has(rv.meta);
+        break :blk try .from(
             allocator,
-            if (rv.meta.len > 0) rv.meta else rv.type,
-            rv.meta.len > 0,
+            if (is_meta) rv.meta else rv.type,
+            is_meta,
             ctx,
-        )
-    else
-        .void;
+        );
+    } else .void;
 
     // TODO: default return values? rv.default_value
 

--- a/pkg/bindgen/codegen.zig
+++ b/pkg/bindgen/codegen.zig
@@ -311,6 +311,7 @@ fn writeClasses(ctx: *const Context) !void {
         try w.writeLine(
             \\
             \\test {
+            \\  @setEvalBranchQuota(20000);
             \\  @import("std").testing.refAllDecls(@This());
             \\}
         );
@@ -1248,25 +1249,13 @@ fn writeImports(w: *CodeWriter, imports: *const Context.Imports, class: ?*const 
     try w.writeLine(
         \\
         \\const std = @import("std");
-        \\
-    );
-
-    // c (gdextension)
-    try w.writeLine(
-        \\const c = @import("gdextension");
-        \\
-    );
-
-    // gdzig with all aliases
-    try w.writeLine(
-        \\const gdzig = @import("gdzig");
-        \\const raw = &gdzig.raw;
     );
 
     // Collect imports into separate lists for sorting
     var builtins: std.ArrayList([]const u8) = .empty;
     var classes: std.ArrayList([]const u8) = .empty;
     var globals: std.ArrayList([]const u8) = .empty;
+    var typedefs: std.ArrayList([]const u8) = .empty;
     const allocator = ctx.arena.allocator();
 
     var iter = imports.iterator();
@@ -1289,7 +1278,7 @@ fn writeImports(w: *CodeWriter, imports: *const Context.Imports, class: ?*const 
         } else if (ctx.flags.contains(import.*)) {
             try globals.append(allocator, import.*);
         } else if (ctx.dispatch_table.typedefs.contains(import.*)) {
-            // TODO: handle gdextension typedefs
+            try typedefs.append(allocator, import.*);
         } else {
             // TODO: native structures?
         }
@@ -1305,6 +1294,26 @@ fn writeImports(w: *CodeWriter, imports: *const Context.Imports, class: ?*const 
     std.mem.sort([]const u8, builtins.items, {}, sortFn);
     std.mem.sort([]const u8, classes.items, {}, sortFn);
     std.mem.sort([]const u8, globals.items, {}, sortFn);
+    std.mem.sort([]const u8, typedefs.items, {}, sortFn);
+
+    // c (gdextension)
+    try w.writeLine(
+        \\
+        \\const c = @import("gdextension");
+    );
+
+    // Write sorted imports (typdefstogether under c)
+    for (typedefs.items) |api_name| {
+        // Note: We do not currently check for name collisions for interface typedefs.
+        try w.printLine("const {0s} = c.{0s};", .{api_name});
+    }
+
+    // gdzig with all aliases
+    try w.writeLine(
+        \\
+        \\const gdzig = @import("gdzig");
+        \\const raw = &gdzig.raw;
+    );
 
     // Write sorted imports (builtins, classes, globals all together under gdzig)
     // Note: import lists contain API names, but we need to use converted names


### PR DESCRIPTION
With godot 4.6 in release candidates, we should be ready to support it. RC 2 was failing to build as there was a unexpected value "required" in the meta field of function arguments, and GDExtensionInitializationFunction is now referenced by GdExtensionManager.

- Ignore new "required" value in the meta field for function arg/return types. This can be changed to be better parsed in the future if there are more useful values of this meta field.
- Increase branch quota for generated refAllDecls tests. The `class.zig` test was failing.
- Re-enable and organize typedef imports for 4.6 GDExtensionInitializationFunction.

Here is also a [branch](https://github.com/gdzig/gdzig/tree/fig-eater/update-example-to-4.6) for updating the example project when we need to.