### PR TITLE
Fix Variant.Tag.forType for optional class pointer types

### DIFF
--- a/src/builtin/variant.zig
+++ b/src/builtin/variant.zig
@@ -586,6 +586,7 @@ pub const Variant = extern struct {
                         .@"enum" => .int,
                         .@"struct" => |info| if (info.backing_integer != null) .int else null,
                         .pointer => |p| if (class.isClassPtr(T)) .object else forType(p.child),
+                        .optional => |o| forType(o.child),
                         else => null,
                     };
                 },

--- a/test/codegen/root.zig
+++ b/test/codegen/root.zig
@@ -16,6 +16,14 @@ test "forType handles optional class pointer types" {
     try std.testing.expectEqual(.object, Variant.Tag.forType(?*Material));
 }
 
+test "Variant.init handles optional class pointer types" {
+    // Variant.init with a null optional class pointer should compile
+    // and produce a nil Variant (no object to upcast).
+    _ = Variant.init(?*Curve, null);
+    _ = Variant.init(?*Noise, null);
+    _ = Variant.init(?*Material, null);
+}
+
 const std = @import("std");
 const gdzig = @import("gdzig");
 const Array = gdzig.builtin.Array;

--- a/test/codegen/root.zig
+++ b/test/codegen/root.zig
@@ -8,6 +8,19 @@ test "default values for basic and flag types" {
     _ = &ArrayMesh.addSurfaceFromArrays;
 }
 
+test "forType handles optional class pointer types" {
+    // Optional class pointers like ?*Curve should resolve to .object,
+    // same as their non-optional counterparts.
+    try std.testing.expectEqual(.object, Variant.Tag.forType(?*Curve));
+    try std.testing.expectEqual(.object, Variant.Tag.forType(?*Noise));
+    try std.testing.expectEqual(.object, Variant.Tag.forType(?*Material));
+}
+
+const std = @import("std");
 const gdzig = @import("gdzig");
 const Array = gdzig.builtin.Array;
 const ArrayMesh = gdzig.class.ArrayMesh;
+const Curve = gdzig.class.Curve;
+const Material = gdzig.class.Material;
+const Noise = gdzig.class.Noise;
+const Variant = gdzig.builtin.Variant;


### PR DESCRIPTION
## Summary

- Handle `.optional` types in `Variant.Tag.forType` by unwrapping and recursing, so `?*Curve`, `?*Noise`, `?*Material` (and any optional class pointer) correctly resolve to `.object`
- Add tests verifying `forType` works with optional class pointer types

Closes #209

The other issue reported in #209 (`Variant.as()` comptime assertion on opaque class pointers) was already resolved by #196.

## Test plan

- [x] `forType(?*Curve)` returns `.object`
- [x] `forType(?*Noise)` returns `.object`
- [x] `forType(?*Material)` returns `.object`

🤖 Generated with [Claude Code](https://claude.com/claude-code)