### PR TITLE
add hot reload support with extension unregister

### DIFF
--- a/example/project/example.gdextension
+++ b/example/project/example.gdextension
@@ -2,6 +2,7 @@
 
 compatibility_minimum = "4.2.0"
 entry_symbol = "my_extension_init"
+reloadable = true
 
 [libraries]
 

--- a/example/src/ExampleNode.zig
+++ b/example/src/ExampleNode.zig
@@ -26,6 +26,10 @@ pub fn register(r: *Registry) void {
     class.addProperty("speed", .{ .getter = .{ .method = get_speed }, .setter = .none });
 }
 
+pub fn unregister(r: *Registry) void {
+    r.removeClass(ExampleNode);
+}
+
 allocator: Allocator,
 base: *Node,
 panel: *PanelContainer = undefined,
@@ -49,6 +53,17 @@ pub fn create(allocator: *Allocator) !*ExampleNode {
     self.base.addChild(.upcast(self.fps_counter), .{});
     self.fps_counter.setPosition(.{ .x = 50, .y = 50 }, .{});
 
+    return self;
+}
+
+pub fn recreate(allocator: *Allocator, obj: *Object) *ExampleNode {
+    const self = allocator.create(ExampleNode) catch @panic("OOM");
+    self.* = .{
+        .allocator = allocator.*,
+        .base = @ptrCast(obj),
+        .fps_counter = .init(),
+    };
+    self.base.setInstance(ExampleNode, self);
     return self;
 }
 
@@ -187,6 +202,7 @@ const HSplitContainer = godot.class.HSplitContainer;
 const ItemList = godot.class.ItemList;
 const Label = godot.class.Label;
 const Node = godot.class.Node;
+const Object = godot.class.Object;
 const PanelContainer = godot.class.PanelContainer;
 const String = godot.builtin.String;
 const Variant = godot.builtin.Variant;

--- a/example/src/GuiNode.zig
+++ b/example/src/GuiNode.zig
@@ -6,9 +6,23 @@ pub fn register(r: *Registry) void {
     class.addMethod("on_toggled", .auto);
 }
 
+pub fn unregister(r: *Registry) void {
+    r.removeClass(GuiNode);
+}
+
 allocator: Allocator,
 base: *Control,
 sprite: *Sprite2D = undefined,
+
+pub fn recreate(allocator: *Allocator, obj: *Object) *GuiNode {
+    const self = allocator.create(GuiNode) catch @panic("OOM");
+    self.* = .{
+        .allocator = allocator.*,
+        .base = @ptrCast(obj),
+    };
+    self.base.setInstance(GuiNode, self);
+    return self;
+}
 
 pub fn create(allocator: *Allocator) !*GuiNode {
     const self = try allocator.create(GuiNode);
@@ -78,6 +92,7 @@ const Button = godot.class.Button;
 const CheckBox = godot.class.CheckBox;
 const Control = godot.class.Control;
 const Engine = godot.class.Engine;
+const Object = godot.class.Object;
 const ResourceLoader = godot.class.ResourceLoader;
 const Sprite2D = godot.class.Sprite2d;
 const String = godot.builtin.String;

--- a/example/src/SignalNode.zig
+++ b/example/src/SignalNode.zig
@@ -20,6 +20,10 @@ pub fn register(r: *Registry) void {
     colors.addProperty("colors_signal3", .auto);
 }
 
+pub fn unregister(r: *Registry) void {
+    r.removeClass(SignalNode);
+}
+
 allocator: Allocator,
 base: *Control, //this makes @Self a valid gdextension class
 color_rect: *ColorRect = undefined,
@@ -34,6 +38,16 @@ pub const Signal1 = struct {
 };
 pub const Signal2 = struct {};
 pub const Signal3 = struct {};
+
+pub fn recreate(allocator: *Allocator, obj: *Object) *SignalNode {
+    const self = allocator.create(SignalNode) catch @panic("OOM");
+    self.* = .{
+        .allocator = allocator.*,
+        .base = @ptrCast(obj),
+    };
+    self.base.setInstance(SignalNode, self);
+    return self;
+}
 
 pub fn create(allocator: *Allocator) !*SignalNode {
     const self = try allocator.create(SignalNode);
@@ -127,6 +141,7 @@ const Color = godot.builtin.Color;
 const ColorRect = godot.class.ColorRect;
 const Control = godot.class.Control;
 const Engine = godot.class.Engine;
+const Object = godot.class.Object;
 const StringName = godot.builtin.StringName;
 const String = godot.builtin.String;
 const Vector3 = godot.builtin.Vector3;

--- a/example/src/SpriteNode.zig
+++ b/example/src/SpriteNode.zig
@@ -23,6 +23,16 @@ pub fn create(allocator: *Allocator) !*SpriteNode {
     return self;
 }
 
+pub fn recreate(allocator: *Allocator, obj: *Object) *SpriteNode {
+    const self = allocator.create(SpriteNode) catch @panic("OOM");
+    self.* = .{
+        .allocator = allocator.*,
+        .base = @ptrCast(obj),
+    };
+    self.base.setInstance(SpriteNode, self);
+    return self;
+}
+
 pub fn destroy(self: *SpriteNode, allocator: *Allocator) void {
     self.base.destroy();
     allocator.destroy(self);
@@ -101,6 +111,7 @@ const godot = @import("godot");
 
 const Control = godot.class.Control;
 const Engine = godot.class.Engine;
+const Object = godot.class.Object;
 const ResourceLoader = godot.class.ResourceLoader;
 const Sprite2D = godot.class.Sprite2d;
 const Texture2D = godot.class.Texture2d;

--- a/example/src/example.zig
+++ b/example/src/example.zig
@@ -8,6 +8,14 @@ pub fn register(r: *Registry) void {
     r.addModule(SignalNode);
 }
 
+pub fn unregister(r: *Registry) void {
+    r.removeModule(SignalNode);
+    r.removeModule(GuiNode);
+    r.removeModule(ExampleNode);
+
+    r.removeClass(SpriteNode);
+}
+
 test "godot version is 4.x" {
     // Tests run inside Godot via `zig build test`
     try std.testing.expectEqual(4, godot.version.major);

--- a/src/extension/Registry.zig
+++ b/src/extension/Registry.zig
@@ -61,6 +61,19 @@ pub fn addModule(self: *Registry, comptime Module: type) void {
     Module.register(self);
 }
 
+/// Remove a module. The module must have a `pub fn unregister(r: *Registry) void` function.
+pub fn removeModule(self: *Registry, comptime Module: type) void {
+    Module.unregister(self);
+}
+
+/// Explicitly unregister a class from Godot's ClassDB.
+/// Inheritors must be unregistered before their parents.
+pub fn removeClass(self: *Registry, comptime T: type) void {
+    _ = self;
+    const class_name: StringName = .fromType(T);
+    classdb.unregisterClass(&class_name);
+}
+
 /// Add lifecycle callbacks.
 pub fn addCallbacks(self: *Registry, comptime T: type, userdata: T, options: Callbacks(T).CreateOptions) void {
     const alloc = self.arena.allocator();

--- a/src/extension/entrypoint.zig
+++ b/src/extension/entrypoint.zig
@@ -43,6 +43,7 @@ fn exit(_: ?*anyopaque, level: gdzig.c.GDExtensionInitializationLevel) callconv(
 
     registry.exit(@enumFromInt(level));
     if (level == @intFromEnum(options.minimum_initialization_level)) {
+        if (@hasDecl(extension, "unregister")) extension.unregister(&registry);
         gdzig.extension.PropertyListInstanceBinding.cleanup();
         gdzig.extension.DestroyInstanceBinding.cleanup();
         registry.deinit();

--- a/src/testing.zig
+++ b/src/testing.zig
@@ -64,6 +64,14 @@ pub fn loadModule(comptime Module: type) void {
     registry.enter(.editor);
 }
 
+pub fn unloadModule(comptime Module: type) void {
+    registry.exit(.editor);
+    registry.exit(.scene);
+    registry.exit(.servers);
+    registry.exit(.core);
+    Module.unregister(&registry);
+}
+
 const builtin = @import("builtin");
 
 const common = @import("common");


### PR DESCRIPTION
the main issue with hot reload support was the new registry/module system not letting us unregister class on extension shutdown.

this adds a callback for "unregister" that is symmetric with "register" for unregistering the extension modules/classes, which fixes hot reload.

I confirmed hot reload in the example project by adding/removing a property and rebuilding while inspecting an extension class.