### PR TITLE
Fix ptrcall widths, pending refs, and enum/flag codegen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ src/class/*.zig
 src/global/*.zig
 !src/builtin/variant.zig
 !src/class/vtable.zig
+!src/class/ptrcall.zig
 !src/**/*.mixin.zig
 !src/**/*.replace.zig
 src/builtin.zig

--- a/pkg/bindgen/Context/Enum.zig
+++ b/pkg/bindgen/Context/Enum.zig
@@ -4,7 +4,7 @@ doc: ?[]const u8 = null,
 module: []const u8 = "",
 name: []const u8 = "_",
 name_api: []const u8 = "_",
-values: StringHashMap(Value) = .empty,
+values: StringArrayHashMap(Value) = .empty,
 
 pub fn fromBuiltin(allocator: Allocator, api: GodotApi.Builtin.Enum) !Enum {
     var self: Enum = .{};
@@ -63,8 +63,7 @@ pub fn deinit(self: *Enum, allocator: Allocator) void {
     if (self.doc) |doc| allocator.free(doc);
     allocator.free(self.module);
     allocator.free(self.name);
-    var values = self.values.valueIterator();
-    while (values.next()) |value| {
+    for (self.values.values()) |*value| {
         value.deinit(allocator);
     }
     self.values.deinit(allocator);
@@ -98,7 +97,7 @@ pub const Value = struct {
 
 const std = @import("std");
 const Allocator = std.mem.Allocator;
-const StringHashMap = std.StringHashMapUnmanaged;
+const StringArrayHashMap = std.StringArrayHashMapUnmanaged;
 const Context = @import("../Context.zig");
 
 const casez = @import("casez");

--- a/pkg/bindgen/Context/Flag.zig
+++ b/pkg/bindgen/Context/Flag.zig
@@ -29,8 +29,16 @@ pub fn fromGlobalEnum(allocator: Allocator, class_name: ?[]const u8, api: GodotA
     self.name_api = api.name;
     self.module = try casez.allocConvert(allocator, gdzig_case.file, self.name);
 
+    // Godot's extension_api.json does not guarantee that power-of-two flag
+    // values are listed in ascending bit order (e.g. RenderingDevice's
+    // TextureUsageBits lists bit 12 before bit 3). Collect the bitfield
+    // members first (recording the _DEFAULT value along the way; Godot
+    // bitfields carry exactly one), then lay them out sorted by bit
+    // position so each field lands at exactly @ctz(its value).
     var default: i64 = 0;
-    var position: u8 = 0;
+
+    var bit_values: std.ArrayListUnmanaged(GodotApi.GlobalEnum.Value) = .empty;
+    defer bit_values.deinit(allocator);
 
     for (api.values) |value| {
         if (std.mem.endsWith(u8, value.name, "_DEFAULT")) {
@@ -40,25 +48,36 @@ pub fn fromGlobalEnum(allocator: Allocator, class_name: ?[]const u8, api: GodotA
         }
 
         if (value.value > 0 and std.math.isPowerOfTwo(value.value)) {
-            const expected_position = @ctz(value.value);
-
-            // Fill in any missing bit positions with placeholder fields
-            while (position < expected_position) : (position += 1) {
-                if (ctx.config.verbosity == .verbose) {
-                    std.debug.print("{s} expected position: {} Actual: {}\n", .{ self.name, expected_position, position });
-                }
-                const name = try std.fmt.allocPrint(allocator, "@\"{d}\"", .{position});
-                try self.fields.put(allocator, name, .{
-                    .name = name,
-                });
-            }
-
-            // Add the field at the correct bit position
-            try self.fields.put(allocator, value.name, try .fromGlobalEnum(allocator, class_name, value, ctx, default));
-            position += 1;
+            try bit_values.append(allocator, value);
         } else {
             try self.consts.put(allocator, value.name, try .fromGlobalEnum(allocator, class_name, value, ctx));
         }
+    }
+
+    std.mem.sort(GodotApi.GlobalEnum.Value, bit_values.items, {}, struct {
+        fn lessThan(_: void, a: GodotApi.GlobalEnum.Value, b: GodotApi.GlobalEnum.Value) bool {
+            return a.value < b.value;
+        }
+    }.lessThan);
+
+    var position: u8 = 0;
+    for (bit_values.items) |value| {
+        const expected_position = @ctz(value.value);
+
+        // Fill in any missing bit positions with placeholder fields
+        while (position < expected_position) : (position += 1) {
+            if (ctx.config.verbosity == .verbose) {
+                std.debug.print("{s} expected position: {} Actual: {}\n", .{ self.name, expected_position, position });
+            }
+            const name = try std.fmt.allocPrint(allocator, "@\"{d}\"", .{position});
+            try self.fields.put(allocator, name, .{
+                .name = name,
+            });
+        }
+
+        // Add the field at the correct bit position
+        try self.fields.put(allocator, value.name, try .fromGlobalEnum(allocator, class_name, value, ctx, default));
+        position += 1;
     }
 
     if (position > 32) {

--- a/pkg/bindgen/Context/Flag.zig
+++ b/pkg/bindgen/Context/Flag.zig
@@ -61,7 +61,21 @@ pub fn fromGlobalEnum(allocator: Allocator, class_name: ?[]const u8, api: GodotA
     }.lessThan);
 
     var position: u8 = 0;
+    var last_value: ?i64 = null;
     for (bit_values.items) |value| {
+        // Some Godot bitfields alias more than one name onto the same bit
+        // (e.g. Mesh.ArrayFormat's ARRAY_FORMAT_CUSTOM1_SHIFT colliding with
+        // ARRAY_FORMAT_TEX_UV2, or PropertyUsageFlags.NO_EDITOR aliasing an
+        // earlier flag). Only the first-declared name for a given value
+        // becomes a packed struct field; later names sharing that value are
+        // emitted as bitcast constants instead, same as non-power-of-two
+        // values.
+        if (last_value == value.value) {
+            try self.consts.put(allocator, value.name, try .fromGlobalEnum(allocator, class_name, value, ctx));
+            continue;
+        }
+        last_value = value.value;
+
         const expected_position = @ctz(value.value);
 
         // Fill in any missing bit positions with placeholder fields

--- a/pkg/bindgen/codegen.zig
+++ b/pkg/bindgen/codegen.zig
@@ -387,13 +387,34 @@ fn writeClass(w: *CodeWriter, class: *const Context.Class, ctx: *const Context) 
 
     // Constructor
     if (class.is_instantiable) {
-        try w.printLine(
-            \\/// Allocates an empty {0s}.
-            \\pub fn init() *{0s} {{
-            \\    return @ptrCast(raw.classdbConstructObject(@ptrCast(&StringName.fromComptimeLatin1("{1s}"))).?);
-            \\}}
-            \\
-        , .{ class.name, class.name_api });
+        if (class.is_refcounted) {
+            // Godot leaves a freshly constructed RefCounted's initial reference
+            // "pending": refcount is 1, but nothing has claimed it yet. The
+            // first time engine code wraps the raw pointer in a Ref<T> (e.g. as
+            // a temporary inside some unrelated method call), it silently
+            // consumes that pending ref without incrementing the count, so
+            // releasing that temporary drops the count to zero and frees the
+            // object out from under the caller. Consuming the pending ref here
+            // (mirroring Ref<T>::instantiate()) makes init() return an object
+            // that is plainly owned at refcount 1, like everything else.
+            try w.printLine(
+                \\/// Allocates an empty {0s} with a refcount of 1, plainly owned by the caller.
+                \\pub fn init() *{0s} {{
+                \\    const self: *{0s} = @ptrCast(raw.classdbConstructObject(@ptrCast(&StringName.fromComptimeLatin1("{1s}"))).?);
+                \\    _ = self.initRef();
+                \\    return self;
+                \\}}
+                \\
+            , .{ class.name, class.name_api });
+        } else {
+            try w.printLine(
+                \\/// Allocates an empty {0s}.
+                \\pub fn init() *{0s} {{
+                \\    return @ptrCast(raw.classdbConstructObject(@ptrCast(&StringName.fromComptimeLatin1("{1s}"))).?);
+                \\}}
+                \\
+            , .{ class.name, class.name_api });
+        }
     }
 
     // Functions

--- a/pkg/bindgen/codegen.zig
+++ b/pkg/bindgen/codegen.zig
@@ -1142,14 +1142,11 @@ fn writeFunctionHeader(w: *CodeWriter, function: *const Context.Function, class:
     if (!function.is_vararg and function.operator_name == null and !function.can_init_directly) {
         try w.printLine("var args: [{d}]c.GDExtensionConstTypePtr = undefined;", .{function.parameters.count()});
         for (function.parameters.values()[0..opt], 0..) |param, i| {
-            try w.printLine("args[{d}] = @ptrCast(&{s});", .{ i, param.name });
+            try writeArgSlot(w, i, &param, null, ctx);
         }
         for (function.parameters.values()[opt..], opt..) |param, i| {
-            if (param.needsRuntimeInit(ctx) or optNullMaterializer(&param, ctx) != null) {
-                try w.printLine("args[{d}] = @ptrCast(&actual_{s});", .{ i, param.name });
-            } else {
-                try w.printLine("args[{d}] = @ptrCast(&opt.{s});", .{ i, param.name });
-            }
+            const materialized = param.needsRuntimeInit(ctx) or optNullMaterializer(&param, ctx) != null;
+            try writeArgSlot(w, i, &param, materialized, ctx);
         }
     }
 
@@ -1213,6 +1210,10 @@ fn writeFunctionHeader(w: *CodeWriter, function: *const Context.Function, class:
             try w.writeAll("var result: ");
             if (function.return_type == .class) {
                 try w.writeLine("?*anyopaque = null;");
+            } else if (wideSlot(&function.return_type, ctx) != .none) {
+                // Widen sub-8-byte scalar/enum/flag returns to an int64 slot so the engine's
+                // 8-byte ptrcall write cannot overrun a narrow result; narrowed in the footer.
+                try w.writeLine("i64 = 0;");
             } else {
                 try writeTypeAtReturn(w, &function.return_type, class, ctx);
                 const return_type_initializer = function.return_type.getDefaultInitializer(ctx);
@@ -1247,6 +1248,56 @@ fn optNullMaterializer(param: *const Context.Function.Parameter, ctx: *const Con
         .basic => param.type.getDefaultInitializer(ctx) orelse ".init()",
         else => null, // .class, .pointer: a null ptrcall slot is a valid null object
     };
+}
+
+/// How a scalar/enum/flag must be marshalled through the ptrcall ABI, which passes every
+/// integer and enum as int64 and every bitfield as int64 (godot-cpp method_ptrcall.h). A
+/// sub-8-byte value needs a widened i64 temporary so the engine reads a full 8 bytes for an
+/// argument (instead of over-reading adjacent stack) and writes a full 8 bytes into a return
+/// slot (instead of over-writing memory past a narrow slot). Floats are already f64 in gdzig
+/// and bool is 1 byte (matches uint8_t), so both marshal as `.none`.
+///
+/// This is the emission-side half of the ABI width rule; `src/class/ptrcall.zig` is the
+/// runtime side, reading/writing the widened slots this function decides to emit.
+const WideSlot = enum { none, int, @"enum", flag };
+
+fn wideSlot(@"type": *const Context.Type, ctx: *const Context) WideSlot {
+    return switch (@"type".*) {
+        .int => |name| if (std.mem.eql(u8, name, "i64") or std.mem.eql(u8, name, "u64")) .none else .int,
+        // Unconditional: writeEnum always emits `enum(i32)`, so no 64-bit enum exists to guard
+        // against, unlike the .int/.flag arms above/below which check the representation width.
+        .@"enum" => .@"enum",
+        .flag => |api_name| if (std.mem.eql(u8, ctx.flagRepr(api_name), "u64")) .none else .flag,
+        else => .none,
+    };
+}
+
+/// Emits `args[i]`, widening sub-8-byte scalars/enums/flags into an int64 temporary whose
+/// address is passed instead of the narrow value's. `materialized` selects the value
+/// expression: `null` for a plain required parameter (`p_name`), `true`/`false` for an
+/// optional parameter's runtime-materialized (`actual_name`) or as-passed (`opt.name`) form.
+fn writeArgSlot(w: *CodeWriter, i: usize, param: *const Context.Function.Parameter, materialized: ?bool, ctx: *const Context) !void {
+    var buf: [128]u8 = undefined;
+    const src = if (materialized) |use_actual|
+        try std.fmt.bufPrint(&buf, "{s}{s}", .{ if (use_actual) "actual_" else "opt.", param.name })
+    else
+        param.name;
+
+    switch (wideSlot(&param.type, ctx)) {
+        .none => try w.printLine("args[{d}] = @ptrCast(&{s});", .{ i, src }),
+        .int => {
+            try w.printLine("const arg{d}_slot: i64 = @intCast({s});", .{ i, src });
+            try w.printLine("args[{d}] = @ptrCast(&arg{d}_slot);", .{ i, i });
+        },
+        .@"enum" => {
+            try w.printLine("const arg{d}_slot: i64 = @intFromEnum({s});", .{ i, src });
+            try w.printLine("args[{d}] = @ptrCast(&arg{d}_slot);", .{ i, i });
+        },
+        .flag => {
+            try w.printLine("const arg{d}_slot: i64 = @as({s}, @bitCast({s}));", .{ i, ctx.flagRepr(param.type.flag), src });
+            try w.printLine("args[{d}] = @ptrCast(&arg{d}_slot);", .{ i, i });
+        },
+    }
 }
 
 fn writeValue(w: *CodeWriter, value: Context.Value, ctx: *const Context) !void {
@@ -1301,10 +1352,12 @@ fn writeFunctionFooter(w: *CodeWriter, function: *const Context.Function, class:
             try w.writeAll("return result.as(");
             try writeTypeAtReturn(w, &function.return_type, class, ctx);
             try w.writeLine(").?;");
-        } else {
-            try w.writeLine(
-                \\return result;
-            );
+        } else switch (wideSlot(&function.return_type, ctx)) {
+            // Narrow the int64 result slot back to the declared sub-8-byte return type.
+            .none => try w.writeLine("return result;"),
+            .int => try w.writeLine("return @intCast(result);"),
+            .@"enum" => try w.writeLine("return @enumFromInt(result);"),
+            .flag => try w.printLine("return @bitCast(@as({s}, @intCast(result)));", .{ctx.flagRepr(function.return_type.flag)}),
         },
     }
 

--- a/pkg/bindgen/codegen.zig
+++ b/pkg/bindgen/codegen.zig
@@ -1127,6 +1127,13 @@ fn writeFunctionHeader(w: *CodeWriter, function: *const Context.Function, class:
                 try w.print("const actual_{s} = opt.{s} orelse ", .{ param.name, param.name });
                 try writeValue(w, param.default.?, ctx);
                 try w.writeLine(";");
+            } else if (!function.is_vararg and function.operator_name == null and !function.can_init_directly) {
+                if (optNullMaterializer(&param, ctx)) |init_expr| {
+                    try w.print("var actual_{s}: ", .{param.name});
+                    try writeTypeAtOptionalParameterField(w, &param.type, class, ctx);
+                    try w.printLine(" = opt.{s} orelse {s};", .{ param.name, init_expr });
+                    try w.printLine("defer if (opt.{0s} == null) actual_{0s}.deinit();", .{param.name});
+                }
             }
         }
     }
@@ -1138,7 +1145,7 @@ fn writeFunctionHeader(w: *CodeWriter, function: *const Context.Function, class:
             try w.printLine("args[{d}] = @ptrCast(&{s});", .{ i, param.name });
         }
         for (function.parameters.values()[opt..], opt..) |param, i| {
-            if (param.needsRuntimeInit(ctx)) {
+            if (param.needsRuntimeInit(ctx) or optNullMaterializer(&param, ctx) != null) {
                 try w.printLine("args[{d}] = @ptrCast(&actual_{s});", .{ i, param.name });
             } else {
                 try w.printLine("args[{d}] = @ptrCast(&opt.{s});", .{ i, param.name });
@@ -1222,6 +1229,24 @@ fn writeFunctionHeader(w: *CodeWriter, function: *const Context.Function, class:
             }
         }
     }
+}
+
+/// For an optional parameter whose nullable default (empty String/Array/Dictionary/...)
+/// maps to a by-value builtin, returns the initializer expression used to materialize a
+/// real empty value at call time. Godot dereferences these builtins' internal pointers, so
+/// a null/undefined optional payload passed as `&opt.name` is a dangling pointer -> segfault.
+/// Returns null when the field is safe to pass by address as-is: object/raw pointers (a null
+/// ptrcall slot is valid) and concrete-value defaults (non-nullable, already materialized).
+fn optNullMaterializer(param: *const Context.Function.Parameter, ctx: *const Context) ?[]const u8 {
+    if (param.needsRuntimeInit(ctx)) return null;
+    const default = param.default orelse return null;
+    if (!default.isNullable()) return null;
+    return switch (param.type) {
+        .array, .string, .string_name, .node_path => ".init()",
+        .variant => ".nil",
+        .basic => param.type.getDefaultInitializer(ctx) orelse ".init()",
+        else => null, // .class, .pointer: a null ptrcall slot is a valid null object
+    };
 }
 
 fn writeValue(w: *CodeWriter, value: Context.Value, ctx: *const Context) !void {

--- a/pkg/bindgen/codegen.zig
+++ b/pkg/bindgen/codegen.zig
@@ -917,11 +917,38 @@ fn writeEnum(w: *CodeWriter, @"enum": *const Context.Enum, ctx: *const Context) 
     try writeDocBlock(w, @"enum".doc);
     try w.printLine("pub const {s} = enum(i32) {{", .{@"enum".name});
     w.indent += 1;
-    var values = @"enum".values.valueIterator();
-    while (values.next()) |value| {
-        try writeDocBlock(w, value.doc);
-        try w.printLine("{s} = {d},", .{ value.name, value.value });
+
+    // Godot enums sometimes alias multiple names onto the same value (e.g.
+    // RenderingDevice.ShaderStage's *_BIT members, or DriverResource's
+    // PHYSICAL_DEVICE/VULKAN_PHYSICAL_DEVICE pair). Zig enums can't have
+    // duplicate tag values, so only the first-declared name per value (in
+    // extension_api.json order) becomes a tag; later names sharing that
+    // value are emitted as alias constants instead. Zig requires all
+    // container fields before any decls, so alias entries are buffered
+    // during this single pass over values and flushed as decls afterward.
+    var seen: std.AutoArrayHashMapUnmanaged(i64, []const u8) = .empty;
+    defer seen.deinit(ctx.rawAllocator());
+
+    const Alias = struct { doc: ?[]const u8, name: []const u8, first_name: []const u8 };
+    var aliases: std.ArrayListUnmanaged(Alias) = .empty;
+    defer aliases.deinit(ctx.rawAllocator());
+
+    for (@"enum".values.values()) |value| {
+        if (seen.get(value.value)) |first_name| {
+            try aliases.append(ctx.rawAllocator(), .{ .doc = value.doc, .name = value.name, .first_name = first_name });
+        } else {
+            try seen.put(ctx.rawAllocator(), value.value, value.name);
+
+            try writeDocBlock(w, value.doc);
+            try w.printLine("{s} = {d},", .{ value.name, value.value });
+        }
     }
+
+    for (aliases.items) |alias| {
+        try writeDocBlock(w, alias.doc);
+        try w.printLine("pub const {s}: @This() = .{s};", .{ alias.name, alias.first_name });
+    }
+
     try writeMixin(w, "global/{s}.mixin.zig", .{@"enum".name}, ctx);
     w.indent -= 1;
     try w.writeLine("};");

--- a/src/builtin/String.mixin.zig
+++ b/src/builtin/String.mixin.zig
@@ -19,12 +19,17 @@ pub inline fn assumeFromUtf8(str: []const u8) String {
 ///
 /// - **cstr**: A slice of UTF-8 encoded bytes.
 ///
-/// **Since Godot 4.3**
+/// On Godot 4.1-4.2, falls back to the (always valid-UTF-8-assuming) deprecated
+/// constructor, which cannot report encoding errors.
 pub inline fn fromUtf8(cstr: []const u8) !String {
     var result: String = undefined;
-    const err = raw.stringNewWithUtf8CharsAndLen2(result.ptr(), @ptrCast(cstr.ptr), @intCast(cstr.len));
-    if (err != 0) {
-        return error.Full;
+    if (raw.stringNewWithUtf8CharsAndLen2) |func| {
+        const err = func(result.ptr(), @ptrCast(cstr.ptr), @intCast(cstr.len));
+        if (err != 0) {
+            return error.Full;
+        }
+    } else {
+        raw.stringNewWithUtf8CharsAndLen(result.ptr(), @ptrCast(cstr.ptr), @intCast(cstr.len));
     }
     return result;
 }
@@ -82,12 +87,17 @@ pub inline fn assumeFromUtf16(utf16: []const u16) String {
 /// - **utf16**: A slice of UTF-16 encoded characters.
 /// - **default_little_endian**: If true, UTF-16 use little endian.
 ///
-/// **Since Godot 4.3**
+/// On Godot 4.1-4.2, falls back to the deprecated constructor (native byte order,
+/// `default_little_endian` is ignored, and encoding errors cannot be reported).
 pub inline fn fromUtf16(utf16: []const u16, default_little_endian: bool) !String {
     var result: String = undefined;
-    const err = raw.stringNewWithUtf16CharsAndLen2(result.ptr(), @ptrCast(utf16.ptr), utf16.len, @intFromBool(default_little_endian));
-    if (err != 0) {
-        return error.Full;
+    if (raw.stringNewWithUtf16CharsAndLen2) |func| {
+        const err = func(result.ptr(), @ptrCast(utf16.ptr), utf16.len, @intFromBool(default_little_endian));
+        if (err != 0) {
+            return error.Full;
+        }
+    } else {
+        raw.stringNewWithUtf16CharsAndLen(result.ptr(), @ptrCast(utf16.ptr), @intCast(utf16.len));
     }
     return result;
 }

--- a/src/class/ptrcall.zig
+++ b/src/class/ptrcall.zig
@@ -1,0 +1,95 @@
+/// Marshalling helpers for Godot's `ptrcall` ABI (used for virtual method
+/// dispatch and for extension methods bound through ClassDB).
+///
+/// Per godot-cpp's `method_ptrcall.h` conventions, ptrcall does not pass
+/// scalars at their declared C width. Instead:
+///
+/// - every integer type (bool included), and every enum or packed flag
+///   struct narrower than 64 bits, travels as a full `int64_t` (8 bytes)
+/// - `u64` (and enums/flags backed by `u64`) travels as `uint64_t`
+/// - `bool` travels as `uint8_t`
+/// - `f32` and `f64` both travel as `double` (8 bytes)
+///
+/// A Zig virtual method or bound method declared with a narrower type (say,
+/// `i32` or `f32`) must still read/write the full slot width, or it will
+/// read stack garbage out of the high bytes (params) or leave garbage in
+/// the high bytes for the engine to read back (returns).
+///
+/// Non-scalar types (structs like `String`/`Vector2`, object pointers,
+/// optionals of object pointers, etc.) are passed at their real, declared
+/// layout and are read/written directly.
+///
+/// This is the runtime-side half of the ABI width rule; `wideSlot` in
+/// `pkg/bindgen/codegen.zig` is the emission side, deciding which generated
+/// call sites need a widened slot in the first place.
+const std = @import("std");
+
+/// Reads a single ptrcall argument slot as `T`, applying the width conventions described
+/// above. `raw_p_arg` accepts both the optional `GDExtensionConstTypePtr` the engine hands us
+/// directly and the already-unwrapped `*const anyopaque` that higher-level callers may have
+/// narrowed it to.
+pub fn readArg(comptime T: type, raw_p_arg: ?*const anyopaque) T {
+    const p_arg: *const anyopaque = @ptrCast(raw_p_arg);
+    return switch (@typeInfo(T)) {
+        .bool => @as(*const u8, @ptrCast(p_arg)).* != 0,
+        .int => @intCast(readIntSlot(T, p_arg)),
+        .float => @floatCast(@as(*const f64, @ptrCast(@alignCast(p_arg))).*),
+        .@"enum" => |info| @enumFromInt(@as(info.tag_type, @intCast(readIntSlot(info.tag_type, p_arg)))),
+        .@"struct" => |info| blk: {
+            if (info.layout != .@"packed") break :blk @as(*const T, @ptrCast(@alignCast(p_arg))).*;
+            const Backing = info.backing_integer.?;
+            break :blk @bitCast(@as(Backing, @intCast(readIntSlot(Backing, p_arg))));
+        },
+        else => @as(*const T, @ptrCast(@alignCast(p_arg))).*,
+    };
+}
+
+/// Writes `value` (of declared type `T`) into a ptrcall return slot, applying the width
+/// conventions described above. The full slot width is always written so no garbage remains
+/// in the high bytes. `raw_p_ret` accepts both the optional `GDExtensionTypePtr` the engine
+/// hands us directly and the already-unwrapped `*anyopaque` that higher-level callers may have
+/// narrowed it to.
+pub fn writeReturn(comptime T: type, raw_p_ret: ?*anyopaque, value: T) void {
+    const p_ret: *anyopaque = @ptrCast(raw_p_ret);
+    switch (@typeInfo(T)) {
+        .bool => @as(*u8, @ptrCast(p_ret)).* = @intFromBool(value),
+        .int => writeIntSlot(T, p_ret, value),
+        .float => @as(*f64, @ptrCast(@alignCast(p_ret))).* = value,
+        .@"enum" => |info| writeIntSlot(info.tag_type, p_ret, @intFromEnum(value)),
+        .@"struct" => |info| {
+            if (info.layout != .@"packed") {
+                @as(*T, @ptrCast(@alignCast(p_ret))).* = value;
+                return;
+            }
+            const Backing = info.backing_integer.?;
+            writeIntSlot(Backing, p_ret, @as(Backing, @bitCast(value)));
+        },
+        else => @as(*T, @ptrCast(@alignCast(p_ret))).* = value,
+    }
+}
+
+/// `u64` is the only integer width that gets its own native slot; every
+/// other integer (regardless of signedness or width, up to 64 bits) travels
+/// as `int64_t`.
+fn isU64Like(bits: u16, signedness: std.builtin.Signedness) bool {
+    return bits == 64 and signedness == .unsigned;
+}
+
+fn readIntSlot(comptime Int: type, p_arg: *const anyopaque) i128 {
+    const info = @typeInfo(Int).int;
+    if (comptime info.bits > 64) @compileError("ptrcall does not support integers wider than 64 bits");
+    if (comptime isU64Like(info.bits, info.signedness)) {
+        return @as(*const u64, @ptrCast(@alignCast(p_arg))).*;
+    }
+    return @as(*const i64, @ptrCast(@alignCast(p_arg))).*;
+}
+
+fn writeIntSlot(comptime Int: type, p_ret: *anyopaque, value: anytype) void {
+    const info = @typeInfo(Int).int;
+    if (comptime info.bits > 64) @compileError("ptrcall does not support integers wider than 64 bits");
+    if (comptime isU64Like(info.bits, info.signedness)) {
+        @as(*u64, @ptrCast(@alignCast(p_ret))).* = @intCast(value);
+    } else {
+        @as(*i64, @ptrCast(@alignCast(p_ret))).* = @intCast(value);
+    }
+}

--- a/src/class/vtable.zig
+++ b/src/class/vtable.zig
@@ -49,8 +49,7 @@ pub fn VTable(comptime T: type, comptime method_names: anytype) type {
                                     method(instance);
                                 } else {
                                     const result = method(instance);
-                                    const ret: *ReturnType = @ptrCast(@alignCast(p_ret));
-                                    ret.* = result;
+                                    ptrcall.writeReturn(ReturnType, p_ret, result);
                                 }
                             }
                         };
@@ -64,14 +63,13 @@ pub fn VTable(comptime T: type, comptime method_names: anytype) type {
                                 args[0] = instance;
                                 inline for (1..param_count) |j| {
                                     const Arg = fn_info.params[j].type.?;
-                                    args[j] = @as(*const Arg, @ptrCast(@alignCast(p_args[j - 1]))).*;
+                                    args[j] = ptrcall.readArg(Arg, p_args[j - 1]);
                                 }
                                 if (ReturnType == void) {
                                     @call(.always_inline, method, args);
                                 } else {
                                     const result = @call(.always_inline, method, args);
-                                    const ret: *ReturnType = @ptrCast(@alignCast(p_ret));
-                                    ret.* = result;
+                                    ptrcall.writeReturn(ReturnType, p_ret, result);
                                 }
                             }
                         };
@@ -179,6 +177,182 @@ test "VTable extend combines method names" {
     try std.testing.expect(Derived.has("_enter_tree")); // new in derived
 }
 
+// The integer/enum/flag assertions below are over-read/portability defense: on a
+// little-endian host, a narrow 4-byte read of a valid int64 slot's low word happens to
+// reproduce the value anyway, so those cases can't actually fail here. The f32 case is the
+// one that discriminates: a narrow read there would misinterpret the low 4 bytes of the
+// double-width slot as bit pattern, so it's the regression guard that actually exercises
+// the width handling.
+test "VTable ptrcall marshals virtual params at engine width" {
+    const ProbeEnum = enum(i32) {
+        zero = 0,
+        one = 1,
+        negative = -7,
+    };
+
+    const Flags = packed struct(u32) {
+        alpha: bool = false,
+        beta: bool = false,
+        _padding: u30 = 0,
+    };
+
+    const Probe = struct {
+        got_i32: i32 = 0,
+        got_u32: u32 = 0,
+        got_f32: f32 = 0,
+        got_bool: bool = false,
+        got_enum: ProbeEnum = .zero,
+        got_flags: Flags = .{},
+
+        pub fn _probeParams(self: *@This(), a: i32, b: u32, c_: f32, d: bool, e: ProbeEnum, f: Flags) void {
+            self.got_i32 = a;
+            self.got_u32 = b;
+            self.got_f32 = c_;
+            self.got_bool = d;
+            self.got_enum = e;
+            self.got_flags = f;
+        }
+    };
+
+    const ProbeVTable = VTable(Probe, .{"_probeParams"});
+    const wrapper = ProbeVTable.get("_probe_params").?;
+
+    // Simulate the engine's ptrcall argument slots: every scalar travels in
+    // a full 8-byte slot (int64/double/uint8), with unused high bytes left
+    // as stack garbage. Poison everything first so a narrow read/write
+    // would be caught reading (or leaving) garbage.
+    var slot_i32: [8]u8 align(8) = .{0xAA} ** 8;
+    std.mem.writeInt(i64, &slot_i32, -12345, .little);
+
+    var slot_u32: [8]u8 align(8) = .{0xAA} ** 8;
+    std.mem.writeInt(i64, &slot_u32, 4_000_000_000, .little); // > i32 max
+
+    var slot_f32: [8]u8 align(8) = .{0xAA} ** 8;
+    std.mem.writeInt(u64, &slot_f32, @as(u64, @bitCast(@as(f64, 3.5))), .little);
+
+    var slot_bool: [8]u8 align(8) = .{0xAA} ** 8;
+    slot_bool[0] = 1;
+
+    var slot_enum: [8]u8 align(8) = .{0xAA} ** 8;
+    std.mem.writeInt(i64, &slot_enum, -7, .little);
+
+    var slot_flags: [8]u8 align(8) = .{0xAA} ** 8;
+    std.mem.writeInt(i64, &slot_flags, 0b10, .little); // beta set, alpha clear
+
+    var args: [6]c.GDExtensionConstTypePtr = .{
+        @ptrCast(&slot_i32),
+        @ptrCast(&slot_u32),
+        @ptrCast(&slot_f32),
+        @ptrCast(&slot_bool),
+        @ptrCast(&slot_enum),
+        @ptrCast(&slot_flags),
+    };
+
+    var probe: Probe = .{};
+    var ret_slot: [8]u8 align(8) = .{0xAA} ** 8;
+
+    wrapper(@ptrCast(&probe), &args, @ptrCast(&ret_slot));
+
+    try std.testing.expectEqual(@as(i32, -12345), probe.got_i32);
+    try std.testing.expectEqual(@as(u32, 4_000_000_000), probe.got_u32);
+    try std.testing.expectEqual(@as(f32, 3.5), probe.got_f32);
+    try std.testing.expectEqual(true, probe.got_bool);
+    try std.testing.expectEqual(ProbeEnum.negative, probe.got_enum);
+    try std.testing.expect(probe.got_flags.beta);
+    try std.testing.expect(!probe.got_flags.alpha);
+}
+
+test "VTable ptrcall marshals virtual returns at engine width" {
+    const ProbeEnum = enum(i16) {
+        neg = -300,
+    };
+
+    const Flags = packed struct(u16) {
+        a: bool = false,
+        b: bool = false,
+        _padding: u14 = 0,
+    };
+
+    const Returns = struct {
+        pub fn _retI32(_: *@This()) i32 {
+            return -123456;
+        }
+        pub fn _retU32(_: *@This()) u32 {
+            return 4_111_222_333;
+        }
+        pub fn _retF32(_: *@This()) f32 {
+            return -2.5;
+        }
+        pub fn _retBool(_: *@This()) bool {
+            return true;
+        }
+        pub fn _retEnum(_: *@This()) ProbeEnum {
+            return .neg;
+        }
+        pub fn _retFlags(_: *@This()) Flags {
+            return .{ .b = true };
+        }
+        pub fn _retU64(_: *@This()) u64 {
+            return 0xFFFF_FFFF_FFFF_FFFF;
+        }
+        pub fn _addAndReturn(_: *@This(), x: i32) i32 {
+            return x + 1;
+        }
+    };
+
+    const ReturnsVTable = VTable(Returns, .{
+        "_retI32", "_retU32", "_retF32", "_retBool", "_retEnum", "_retFlags", "_retU64", "_addAndReturn",
+    });
+    var instance: Returns = .{};
+    const instance_ptr: c.GDExtensionClassInstancePtr = @ptrCast(&instance);
+    var no_args: [0]c.GDExtensionConstTypePtr = .{};
+
+    {
+        var ret: [8]u8 align(8) = .{0xAA} ** 8;
+        ReturnsVTable.get("_ret_i32").?(instance_ptr, &no_args, @ptrCast(&ret));
+        try std.testing.expectEqual(@as(i64, -123456), std.mem.readInt(i64, &ret, .little));
+    }
+    {
+        var ret: [8]u8 align(8) = .{0xAA} ** 8;
+        ReturnsVTable.get("_ret_u32").?(instance_ptr, &no_args, @ptrCast(&ret));
+        try std.testing.expectEqual(@as(i64, 4_111_222_333), std.mem.readInt(i64, &ret, .little));
+    }
+    {
+        var ret: [8]u8 align(8) = .{0xAA} ** 8;
+        ReturnsVTable.get("_ret_f32").?(instance_ptr, &no_args, @ptrCast(&ret));
+        const bits = std.mem.readInt(u64, &ret, .little);
+        try std.testing.expectEqual(@as(f64, -2.5), @as(f64, @bitCast(bits)));
+    }
+    {
+        var ret: [8]u8 align(8) = .{0xAA} ** 8;
+        ReturnsVTable.get("_ret_bool").?(instance_ptr, &no_args, @ptrCast(&ret));
+        try std.testing.expectEqual(@as(u8, 1), ret[0]);
+    }
+    {
+        var ret: [8]u8 align(8) = .{0xAA} ** 8;
+        ReturnsVTable.get("_ret_enum").?(instance_ptr, &no_args, @ptrCast(&ret));
+        try std.testing.expectEqual(@as(i64, -300), std.mem.readInt(i64, &ret, .little));
+    }
+    {
+        var ret: [8]u8 align(8) = .{0xAA} ** 8;
+        ReturnsVTable.get("_ret_flags").?(instance_ptr, &no_args, @ptrCast(&ret));
+        try std.testing.expectEqual(@as(i64, 0b10), std.mem.readInt(i64, &ret, .little));
+    }
+    {
+        var ret: [8]u8 align(8) = .{0xAA} ** 8;
+        ReturnsVTable.get("_ret_u64").?(instance_ptr, &no_args, @ptrCast(&ret));
+        try std.testing.expectEqual(@as(u64, 0xFFFF_FFFF_FFFF_FFFF), std.mem.readInt(u64, &ret, .little));
+    }
+    {
+        var arg_slot: [8]u8 align(8) = .{0xAA} ** 8;
+        std.mem.writeInt(i64, &arg_slot, 41, .little);
+        var args: [1]c.GDExtensionConstTypePtr = .{@ptrCast(&arg_slot)};
+        var ret: [8]u8 align(8) = .{0xAA} ** 8;
+        ReturnsVTable.get("_add_and_return").?(instance_ptr, &args, @ptrCast(&ret));
+        try std.testing.expectEqual(@as(i64, 42), std.mem.readInt(i64, &ret, .little));
+    }
+}
+
 const std = @import("std");
 
 const c = @import("gdextension");
@@ -187,3 +361,4 @@ const gdzig = @import("gdzig");
 const common = @import("common");
 const godot_case = common.godot_case;
 const class = gdzig.class;
+const ptrcall = @import("ptrcall.zig");

--- a/src/extension/method.zig
+++ b/src/extension/method.zig
@@ -7,6 +7,7 @@ const godot_case = common.godot_case;
 
 const gdzig = @import("gdzig");
 const class = gdzig.class;
+const ptrcall = @import("../class/ptrcall.zig");
 const classdb = gdzig.class.ClassDb;
 const MethodFlags = gdzig.global.MethodFlags;
 const StringName = gdzig.builtin.StringName;
@@ -116,7 +117,7 @@ pub fn MethodConfig(comptime Class: type) type {
                     } else {
                         const result = @call(.auto, method, call_args);
                         if (ret) |r| {
-                            @as(*ReturnType, @ptrCast(@alignCast(r))).* = result;
+                            ptrcall.writeReturn(ReturnType, r, result);
                         }
                     }
                 }
@@ -128,7 +129,7 @@ pub fn MethodConfig(comptime Class: type) type {
                     } else if (comptime class.isOpaqueClassPtr(ArgType)) {
                         return @ptrCast(@constCast(p_arg));
                     } else {
-                        return @as(*const ArgType, @ptrCast(@alignCast(p_arg))).*;
+                        return ptrcall.readArg(ArgType, p_arg);
                     }
                 }
             };
@@ -161,7 +162,7 @@ pub fn MethodConfig(comptime Class: type) type {
 
                 fn ptrCall(instance: *Class, _: [*]const *const anyopaque, ret: ?*anyopaque) void {
                     if (ret) |r| {
-                        @as(*FieldType, @ptrCast(@alignCast(r))).* = @field(instance, field_name);
+                        ptrcall.writeReturn(FieldType, r, @field(instance, field_name));
                     }
                 }
             };
@@ -193,7 +194,7 @@ pub fn MethodConfig(comptime Class: type) type {
                 }
 
                 fn ptrCall(instance: *Class, args: [*]const *const anyopaque, _: ?*anyopaque) void {
-                    @field(instance, field_name) = @as(*const FieldType, @ptrCast(@alignCast(args[0]))).*;
+                    @field(instance, field_name) = ptrcall.readArg(FieldType, args[0]);
                 }
             };
 

--- a/test/codegen/root.zig
+++ b/test/codegen/root.zig
@@ -68,6 +68,38 @@ test "Bug A: omitting nullable String optional arg materializes empty default" {
     try testing.expect(parts.size() >= 1);
 }
 
+noinline fn poisonStack() void {
+    var buf: [8192]u8 = undefined;
+    for (&buf) |*b| b.* = 0xAA;
+    std.mem.doNotOptimizeAway(&buf);
+}
+
+// Bug B: sub-8-byte scalar/enum/flag args and returns must be marshalled through int64
+// temporaries to match the ptrcall ABI (godot-cpp method_ptrcall.h). These round-trips
+// exercise the widened arg-encode and return-narrow paths under a poisoned stack, guarding
+// against the out-of-bounds arg read / return-slot overwrite the narrow marshalling caused.
+test "Bug B: enum arg and return round-trip under poisoned stack" {
+    poisonStack();
+
+    const node = Node.init();
+    defer node.destroy();
+
+    node.setProcessMode(.process_mode_disabled);
+
+    poisonStack();
+    try testing.expectEqual(Node.ProcessMode.process_mode_disabled, node.getProcessMode());
+}
+
+test "Bug B: i32 return under poisoned stack" {
+    poisonStack();
+
+    const node = Node.init();
+    defer node.destroy();
+
+    poisonStack();
+    try testing.expectEqual(@as(i32, 0), node.getChildCount(.{}));
+}
+
 const std = @import("std");
 const testing = std.testing;
 

--- a/test/codegen/root.zig
+++ b/test/codegen/root.zig
@@ -26,6 +26,20 @@ test "flag bits are laid out by value, not declaration order" {
     );
 }
 
+test "enums with duplicate values alias the first declared member" {
+    // RenderingDevice.ShaderStage aliases bit-shifted values onto the plain stage
+    // enumerators (e.g. SHADER_STAGE_VERTEX_BIT == SHADER_STAGE_FRAGMENT == 1); only
+    // the first-declared name for each value may become an enum tag, later members
+    // with the same value must be alias constants equal to it.
+    try std.testing.expectEqual(@as(i32, 4), @intFromEnum(RenderingDevice.ShaderStage.shader_stage_compute));
+    try std.testing.expectEqual(RenderingDevice.ShaderStage.shader_stage_fragment, RenderingDevice.ShaderStage.shader_stage_vertex_bit);
+    try std.testing.expectEqual(RenderingDevice.ShaderStage.shader_stage_tesselation_control, RenderingDevice.ShaderStage.shader_stage_fragment_bit);
+
+    // RenderingDevice.DriverResource has DRIVER_RESOURCE_VULKAN_PHYSICAL_DEVICE aliasing
+    // the earlier-declared DRIVER_RESOURCE_PHYSICAL_DEVICE (both == 1).
+    try std.testing.expectEqual(RenderingDevice.DriverResource.driver_resource_physical_device, RenderingDevice.DriverResource.driver_resource_vulkan_physical_device);
+}
+
 const std = @import("std");
 const gdzig = @import("gdzig");
 const Array = gdzig.builtin.Array;

--- a/test/codegen/root.zig
+++ b/test/codegen/root.zig
@@ -8,6 +8,26 @@ test "default values for basic and flag types" {
     _ = &ArrayMesh.addSurfaceFromArrays;
 }
 
+test "flag bits are laid out by value, not declaration order" {
+    // RenderingDevice.TextureUsageBits lists TEXTURE_USAGE_DEPTH_RESOLVE_ATTACHMENT_BIT
+    // (bit 12) before TEXTURE_USAGE_STORAGE_BIT (bit 3) in extension_api.json. Each
+    // field must still land at its own bit position regardless of that ordering.
+    try std.testing.expectEqual(
+        @as(u32, 1),
+        @as(u32, @bitCast(RenderingDevice.TextureUsageBits{ .texture_usage_sampling_bit = true })),
+    );
+    try std.testing.expectEqual(
+        @as(u32, 8),
+        @as(u32, @bitCast(RenderingDevice.TextureUsageBits{ .texture_usage_storage_bit = true })),
+    );
+    try std.testing.expectEqual(
+        @as(u32, 128),
+        @as(u32, @bitCast(RenderingDevice.TextureUsageBits{ .texture_usage_can_copy_from_bit = true })),
+    );
+}
+
+const std = @import("std");
 const gdzig = @import("gdzig");
 const Array = gdzig.builtin.Array;
 const ArrayMesh = gdzig.class.ArrayMesh;
+const RenderingDevice = gdzig.class.RenderingDevice;

--- a/test/codegen/root.zig
+++ b/test/codegen/root.zig
@@ -40,8 +40,41 @@ test "enums with duplicate values alias the first declared member" {
     try std.testing.expectEqual(RenderingDevice.DriverResource.driver_resource_physical_device, RenderingDevice.DriverResource.driver_resource_vulkan_physical_device);
 }
 
+// Bug A: omitting an optional argument whose default is a nullable heap builtin
+// (String/StringName/Array/Dictionary/...) must materialize a real empty value.
+// Pre-fix the generated code passed `&opt.name` where the `?T` field was null, so
+// Godot dereferenced a null Array/Dictionary internal pointer -> segfault.
+test "Bug A: omitting nullable Array optional arg does not segfault" {
+    const node = Node.init();
+    defer node.destroy();
+
+    // addUserSignal(signal, opt: { arguments: ?Array = null }); omit arguments.
+    var name: String = .fromLatin1("my_signal");
+    defer name.deinit();
+    node.addUserSignal(name, .{});
+
+    var sig: StringName = .fromLatin1("my_signal", false);
+    defer sig.deinit();
+    try testing.expect(node.hasUserSignal(sig));
+}
+
+test "Bug A: omitting nullable String optional arg materializes empty default" {
+    var s: String = .fromLatin1("a,b,c");
+    defer s.deinit();
+
+    var parts = s.split(.{});
+    defer parts.deinit();
+
+    try testing.expect(parts.size() >= 1);
+}
+
 const std = @import("std");
+const testing = std.testing;
+
 const gdzig = @import("gdzig");
 const Array = gdzig.builtin.Array;
+const String = gdzig.builtin.String;
+const StringName = gdzig.builtin.StringName;
 const ArrayMesh = gdzig.class.ArrayMesh;
 const RenderingDevice = gdzig.class.RenderingDevice;
+const Node = gdzig.class.Node;

--- a/test/leaks/root.zig
+++ b/test/leaks/root.zig
@@ -1,3 +1,34 @@
+pub fn register(r: *gdzig.extension.Registry) void {
+    const class = r.createClass(RefReturnNode, {}, .auto);
+    class.addMethod("get_borrowed_resource", .auto);
+}
+
+fn ensureRegistered() void {
+    const S = struct {
+        var done: bool = false;
+    };
+    if (!S.done) {
+        S.done = true;
+        gdzig.testing.loadModule(@This());
+    }
+}
+
+test "Variant return from bound method holds a reference to borrowed RefCounted" {
+    ensureRegistered();
+
+    const node = try RefReturnNode.create();
+    defer node.base.destroy();
+
+    try testing.expectEqual(@as(i32, 1), node.resource.getReferenceCount());
+
+    var result = Object.call(.upcast(node), .fromComptimeLatin1("get_borrowed_resource"), .{});
+    try testing.expectEqual(node.resource, result.as(*Resource).?);
+    try testing.expectEqual(@as(i32, 2), node.resource.getReferenceCount());
+
+    result.deinit();
+    try testing.expectEqual(@as(i32, 1), node.resource.getReferenceCount());
+}
+
 test "engine object survives a temporary Ref taken by an engine call" {
     const resource = Resource.init();
     try testing.expectEqual(@as(i32, 1), resource.getReferenceCount());
@@ -36,11 +67,39 @@ test "variant reference counting" {
     object.destroy();
 }
 
+const RefReturnNode = struct {
+    base: *Node,
+    resource: *Resource,
+
+    pub fn create() !*RefReturnNode {
+        const self: *RefReturnNode = allocator.create(RefReturnNode) catch @panic("out of memory");
+        self.* = .{
+            .base = Node.init(),
+            .resource = Resource.init(),
+        };
+        self.base.setInstance(RefReturnNode, self);
+        return self;
+    }
+
+    pub fn destroy(self: *RefReturnNode) void {
+        if (!self.resource.unreference()) @panic("resource still has external references");
+        self.resource.destroy();
+        allocator.destroy(self);
+    }
+
+    pub fn getBorrowedResource(self: *RefReturnNode) *Resource {
+        return self.resource;
+    }
+};
+
 const std = @import("std");
 const testing = std.testing;
 
 const gdzig = @import("gdzig");
 const general = gdzig.general;
+const allocator = gdzig.testing.allocator;
+const Node = gdzig.class.Node;
+const Object = gdzig.class.Object;
 const RefCounted = gdzig.class.RefCounted;
 const Resource = gdzig.class.Resource;
 const ResourceSaver = gdzig.class.ResourceSaver;

--- a/test/leaks/root.zig
+++ b/test/leaks/root.zig
@@ -1,3 +1,23 @@
+test "engine object survives a temporary Ref taken by an engine call" {
+    const resource = Resource.init();
+    try testing.expectEqual(@as(i32, 1), resource.getReferenceCount());
+
+    // ResourceSaver.getRecognizedExtensions takes its `Resource` argument by
+    // `const Ref<Resource> &` on the engine side. Godot constructs a temporary
+    // Ref<Resource> around our raw pointer for the duration of this call, and
+    // releases it before returning. If init() left the object's "pending"
+    // ref uninitialized, this temporary Ref is treated as the first-ever
+    // wrap, and releasing it drops the refcount to zero and frees the object
+    // out from under us.
+    var extensions = ResourceSaver.getRecognizedExtensions(resource);
+    defer extensions.deinit();
+
+    try testing.expectEqual(@as(i32, 1), resource.getReferenceCount());
+
+    try testing.expect(resource.unreference());
+    resource.destroy();
+}
+
 test "variant reference counting" {
     const object = RefCounted.init();
     try testing.expectEqual(@as(i32, 1), object.getReferenceCount());
@@ -22,4 +42,6 @@ const testing = std.testing;
 const gdzig = @import("gdzig");
 const general = gdzig.general;
 const RefCounted = gdzig.class.RefCounted;
+const Resource = gdzig.class.Resource;
+const ResourceSaver = gdzig.class.ResourceSaver;
 const Variant = gdzig.builtin.Variant;

--- a/test/variant/root.zig
+++ b/test/variant/root.zig
@@ -26,6 +26,29 @@ test "basic construction - string" {
     try testing.expectEqual(Variant.Tag.string, str_var.tag);
 }
 
+test "basic construction - string from utf8" {
+    const input = "h\u{e9}llo \u{2728} \u{65e5}\u{672c}\u{8a9e}";
+
+    var str = try String.fromUtf8(input);
+    defer str.deinit();
+
+    var buf: [128]u8 = undefined;
+    const slice = str.toUtf8Buf(&buf);
+    try testing.expectEqualStrings(input, slice);
+}
+
+test "basic construction - string from utf16" {
+    const arr = [_]u16{ 'h', 'i', 0x2728 }; // "hi✨"
+    const input: []const u16 = arr[0..];
+
+    var str = try String.fromUtf16(input, true);
+    defer str.deinit();
+
+    var buf: [16]u16 = undefined;
+    const slice = str.toUtf16Buf(&buf);
+    try testing.expectEqualSlices(u16, input, slice);
+}
+
 test "clone" {
     const original = Variant.init(i64, 123);
     defer original.deinit();


### PR DESCRIPTION
## Summary

I've been porting a mature C++ GDExtension (hardware video playback) to Zig, and gdzig got me really far, really fast. It also walked me into seven marshalling and codegen bugs, most of which show up as memory corruption or a segfault under real engine traffic rather than anything the compiler catches. Each one is its own commit here, with a regression test.

Three of them share the same root cause: Godot's ptrcall ABI passes every scalar at a fixed width (ints/enums/flags as int64, bool as uint8, floats as double), while the generated code was reading and writing at the declared Zig width.

- `fix: marshal virtual scalars at ptrcall widths`: virtual method wrappers and the ClassDB ptrcall/getter/setter paths left stack garbage in the high bytes of anything narrower than 8 bytes. Adds `src/class/ptrcall.zig` with readArg/writeReturn helpers used by both paths.
- `fix: marshal sub-8-byte ptrcall args and returns as int64`: same ABI, other direction. Passing `&value` for a narrow enum, flag, or int let the engine over-read the stack on arguments and over-write past the return slot.
- `fix: consume pending ref in RefCounted init`: Godot leaves a fresh RefCounted's first ref "pending", and the first engine-side `Ref<T>` wrap consumes it without incrementing. So passing a newly init'd object into any engine method could free it while you still hold it. `init()` now claims the pending ref up front, which mirrors godot-cpp's `Ref<T>::instantiate()`.
- `fix: materialize omitted nullable builtin args`: omitting an optional Array/Dictionary/String arg passed a pointer to a null optional, which the engine dereferenced as a live builtin. Segfault. The call site now builds a real empty value and deinits it after.
- `fix: unwrap optional dispatch fn in String.fromUtf8/16`: the 4.3+ constructor symbol is an optional dispatch table field, so calling it directly is a compile error, and lazy analysis meant nothing caught it until you actually call `fromUtf8`. Now unwraps with a fallback to the 4.1 constructor, same pattern as `StringName.fromUtf8`.
- `fix(bindgen): place flag bits by value, not decl order`: extension_api.json doesn't guarantee bitfield members arrive in ascending bit order (RenderingDevice.TextureUsageBits lists bit 12 before bit 3), so packed struct fields could land on the wrong bits.
- `fix(bindgen): alias duplicate-value enum/flag members`: Godot sometimes declares two names for the same value (ShaderStage's `*_BIT` twins, DriverResource, Mesh.ArrayFormat's shift constants). Emitting each as a real tag produces an enum Zig rejects at first use. The first-declared name stays the tag and later ones become alias constants. One thing worth knowing if you touch this later: Zig won't let decls interleave with enum fields, so the aliases have to be emitted after all the fields.

## Test plan

- [x] `zig build test` against Godot 4.6.3: 126/126 steps, 70/70 tests
- [x] Every fix lands with a regression test that fails without it
- [x] All seven have been running under a real extension (multi-stream video playback on macOS) for a while now

One more thing: if it's useful for #217, I have these exact commits cherry-picked onto the zig-0.16 branch (they applied with zero conflicts), sitting on my fork as `media-streams-fixes-0.16`. Happy to PR that separately once 217 lands.
