### PR TITLE
fix(bindgen): resolve class-local flag reprs from the API during class casting

### DIFF
--- a/pkg/bindgen/Context.zig
+++ b/pkg/bindgen/Context.zig
@@ -395,13 +395,44 @@ fn castEnums(self: *Context) !void {
 
 /// Resolves the backing type name ("u32" or "u64") for a flag, searching
 /// global flags first, then class-level flags for qualified names like "Mesh.ArrayFormat".
+///
+/// The maps are empty while classes are being cast (castClasses runs before
+/// castEnums/castFlags in build()), so method parameter defaults resolved
+/// during class casting fall back to scanning the raw API. A wrong fallback
+/// produces `@bitCast(@as(u64, 0))` into a packed struct(u32) — a compile
+/// error in every generated class whose flag has < 33 bit positions.
 pub fn flagRepr(self: *const Context, flag_name: []const u8) []const u8 {
     if (self.flags.get(flag_name)) |f| return f.representation.name();
     if (std.mem.indexOfScalar(u8, flag_name, '.')) |dot| {
         if (self.classes.get(flag_name[0..dot])) |class|
             if (class.flags.get(flag_name[dot + 1 ..])) |f| return f.representation.name();
+        for (self.api.classes) |api_class| {
+            if (!std.mem.eql(u8, api_class.name, flag_name[0..dot])) continue;
+            const enums = api_class.enums orelse break;
+            for (enums) |e| {
+                if (!e.is_bitfield or !std.mem.eql(u8, e.name, flag_name[dot + 1 ..])) continue;
+                return apiEnumRepr(e.values);
+            }
+            break;
+        }
+    } else {
+        for (self.api.global_enums) |e| {
+            if (!e.is_bitfield or !std.mem.eql(u8, e.name, flag_name)) continue;
+            return apiEnumRepr(e.values);
+        }
     }
     return "u64";
+}
+
+/// Mirrors the representation rule in Flag.fromGlobalEnum: u64 iff any
+/// power-of-two value occupies a bit position >= 32.
+fn apiEnumRepr(values: anytype) []const u8 {
+    for (values) |v| {
+        if (v.value > 0 and std.math.isPowerOfTwo(v.value) and @ctz(@as(u64, @intCast(v.value))) >= 32) {
+            return "u64";
+        }
+    }
+    return "u32";
 }
 
 fn castFlags(self: *Context) !void {


### PR DESCRIPTION
## Summary

Extends `Context.flagRepr` in `pkg/bindgen/Context.zig` with a raw-`GodotApi` fallback so class-method flag-typed parameter defaults emit the correct sized `@bitCast(@as(u32, 0))` instead of an unsized `@bitCast(@as(u64, 0))` into a packed `struct(u32)` flag type.

Upstream [#208][pr-208] already introduced the `flagRepr` helper and added two lookup maps (`self.flags` and `self.classes[name].flags`) for the post-`castFlags` phase. But `castClasses` runs **before** `castEnums`/`castFlags` in `Context.build()`, so those maps are empty while class methods are being cast. Without this patch, every class-method flag-typed parameter default that goes through `flagRepr` walks the `return "u64"` line and emits an incorrect `@bitCast(@as(u64, 0))` into packed `struct(u32)` flag types — a hard Zig compile error at any analyzed call site (e.g. `ResourceSaver.save` on Godot 4.5).

## Diff

`pkg/bindgen/Context.zig`, `+31 / -0`. Extends `pub fn flagRepr` with two new fall-through branches before the existing return:

1. **Class-qualified lookup** (when `flag_name` contains a dot): scan `self.api.classes` for the class name, then scan that class's `enums` for an `is_bitfield` entry whose `name` matches `flag_name[dot+1..]`, returning `apiEnumRepr(e.values)`.
2. **Top-level fallback** (no dot): scan `self.api.global_enums` for an `is_bitfield` entry whose `name` matches `flag_name`, returning `apiEnumRepr(e.values)`.

New helper `fn apiEnumRepr(values: anytype) []const u8`: returns `"u64"` iff any value is a power of two whose `ctz` is `>= 32`; otherwise `"u32"`. Mirrors the rule in `Flag.fromGlobalEnum`.

## Test plan

- [x] `zig build check` on the rebased branch: exit 0
- [x] Compared rebased branch's generated `bindings/class/resource_saver.zig` against upstream `master`'s on Godot 4.5's `extension_api.json`:
  - **Upstream master:** `flags: ResourceSaver.SaverFlags = @bitCast(@as(u64, 0))` — **compile error** against `packed struct(u32) SaverFlags`.
  - **Rebased:** `flags: ResourceSaver.SaverFlags = @bitCast(@as(u32, 0))` — **fixed**.

## Why this is upstream-ready

- The patch is a strict superset of upstream's existing `flagRepr` behaviour and is additive only — no existing call sites change.
- It does not duplicate upstream's two lookup maps; it adds a separate fallback layer for the moment in `Context.build()` when those maps are empty.
- The cherry-pick applies cleanly against current `master` (zero conflicts), as does its stack with the Godot 4.7 compat patch ([fork commit `6cbf405`][fork-6cbf405]).

Original fork commit: [`667cc01`][fork-667cc01].

[pr-208]: https://github.com/gdzig/gdzig/pull/208
[fork-667cc01]: https://github.com/gtmacdonald/gdzig/commit/667cc01c72bba2173035e704231a5ec244bc05cd
[fork-6cbf405]: https://github.com/gtmacdonald/gdzig/commit/6cbf40570117c96dc5629499e7ec6775023fbf8d
