### PR TITLE
fix(bindgen): support Godot 4.7 extension_api.json schema

### DIFF
--- a/pkg/bindgen/GodotApi.zig
+++ b/pkg/bindgen/GodotApi.zig
@@ -223,7 +223,9 @@ pub const Class = struct {
 
 pub const GlobalConstant = struct {
     name: []const u8,
-    value: []const u8,
+    // Numeric since Godot 4.7 populates global_constants (was always empty
+    // before, with a string-typed placeholder here).
+    value: i64,
 };
 
 pub const GlobalEnum = struct {
@@ -313,7 +315,11 @@ pub fn findParent(self: @This(), class: Class) ?Class {
 pub fn parseFromReader(arena: *ArenaAllocator, reader: *Reader) !Parsed(GodotApi) {
     var json_reader: JsonReader = .init(arena.allocator(), reader);
 
-    return try std.json.parseFromTokenSource(GodotApi, arena.allocator(), &json_reader, .{});
+    return try std.json.parseFromTokenSource(GodotApi, arena.allocator(), &json_reader, .{
+        // Newer Godot releases add fields to extension_api.json (e.g. 4.7);
+        // tolerate them instead of failing the whole parse.
+        .ignore_unknown_fields = true,
+    });
 }
 
 const std = @import("std");

--- a/src/class/Object.mixin.zig
+++ b/src/class/Object.mixin.zig
@@ -111,9 +111,9 @@ pub fn disconnect(self: *Self, comptime S: type, callable: Callable) void {
 }
 
 /// Emits a signal. Guarantees no allocations when calling across the FFI. Passing Transform2D, AABB, Basis, Transform3D, or Projection is a compile error; use the Alloc variant.
-pub fn emit(self: *Self, comptime Signal: type, signal: AssertNonAllocating(Signal)) EmitError!void {
-    const signal_name: StringName = .fromSignal(Signal);
-    const fields = @typeInfo(Signal).@"struct".fields;
+pub fn emit(self: *Self, comptime S: type, signal: AssertNonAllocating(S)) EmitError!void {
+    const signal_name: StringName = .fromSignal(S);
+    const fields = @typeInfo(S).@"struct".fields;
     var args: [fields.len]Variant = undefined;
     inline for (fields, 0..) |field, i| {
         args[i] = Variant.init(field.type, @field(signal, field.name));
@@ -123,9 +123,9 @@ pub fn emit(self: *Self, comptime Signal: type, signal: AssertNonAllocating(Sign
 }
 
 /// Emits a signal. Will necessarily allocate when calling across the FFI with Transform2d, Aabb, Basis, Transform3d, or Projection.
-pub fn emitAlloc(self: *Self, comptime Signal: type, signal: Signal) EmitError!void {
-    const signal_name: StringName = .fromSignal(Signal);
-    const fields = @typeInfo(Signal).@"struct".fields;
+pub fn emitAlloc(self: *Self, comptime S: type, signal: S) EmitError!void {
+    const signal_name: StringName = .fromSignal(S);
+    const fields = @typeInfo(S).@"struct".fields;
     var args: [fields.len]Variant = undefined;
     inline for (fields, 0..) |field, i| {
         args[i] = Variant.init(field.type, @field(signal, field.name));
@@ -150,16 +150,16 @@ fn emitImpl(self: *Self, signal_name: StringName, args: anytype) EmitError!void 
     }
 }
 
-/// Returns Signal if no fields allocate, otherwise generates a compile error.
-fn AssertNonAllocating(comptime Signal: type) type {
-    const fields = @typeInfo(Signal).@"struct".fields;
+/// Returns the signal type if no fields allocate, otherwise generates a compile error.
+fn AssertNonAllocating(comptime S: type) type {
+    const fields = @typeInfo(S).@"struct".fields;
     inline for (fields) |field| {
         if (allocatesAsVariant(field.type)) {
             @compileError("Signal field '" ++ field.name ++ "' has type " ++ @typeName(field.type) ++
                 " which allocates when wrapped in Variant. Use emitAlloc instead.");
         }
     }
-    return Signal;
+    return S;
 }
 
 const allocatesAsVariant = Variant.Tag.allocatesForType;


### PR DESCRIPTION
## Summary

Three independent fixes that together allow regenerating `pkg/bindgen/GodotApi.zig` and the generated bindings against Godot 4.7's `extension_api.json`. Without any one of them, the regen fails — either at JSON parse time or at Zig compile time inside the generated mixin.

## Sub-fixes

1. **`pkg/bindgen/GodotApi.zig` — `GlobalConstant.value: []const u8` → `value: i64`** (+1/-1)

   Godot 4.7 populates `global_constants` (formerly always empty) with numeric values; the placeholder string type no longer parses the JSON.

2. **`pkg/bindgen/GodotApi.zig` — pass `.{ .ignore_unknown_fields = true }` to `std.json.parseFromTokenSource`** (+7/-1)

   4.7 adds fields like `builtin_classes[].methods[].hash_compatibility` that the strict schema rejects with `UnexpectedToken`.

3. **`src/class/Object.mixin.zig` — rename the `comptime Signal: type` parameter on `emit`, `emitAlloc`, and `AssertNonAllocating` to `comptime S: type`** (+10/-10)

   4.7's `Tween` gained `Signal`-typed method parameters, so the generated `tween.zig` gets a top-level `Signal` import that the mixin's `comptime Signal` parameter then illegally shadows. Renaming the mixin's parameter to `S` (mirroring how `GenericAtomic`/`GenericAtomicNode` are named elsewhere in the file) avoids the collision without affecting generated code outside the mixin body.

## Test plan

- [x] `git diff upstream/master HEAD --stat`: `+18 / -12` across 2 files — matches the spec exactly
- [x] `git diff <fork 6cbf405> HEAD -- pkg/bindgen/GodotApi.zig src/class/Object.mixin.zig`: **zero lines** — content preserved 1:1
- [x] `zig build check` on rebased branch: exit 0
- [x] `zig build` for the procedural-tools superproject: `gdzig-bindgen` codegen step succeeds; remaining errors are unrelated downstream (TidxResource schema drift is fork-only).

## Why this is upstream-ready

- All three sub-fixes are additive or mechanical renames; no upstream API surface changes.
- The patch's two-file, two-hunk shape applies cleanly against `upstream/master` (zero conflicts) and stacks cleanly with the class-local `flagRepr` fallback in PR companion ([fork `667cc01`][fork-667cc01]).
- Sub-fixes 1 and 2 will land naturally whenever upstream cuts a 4.7 regen; sub-fix 3 is a generated-code shape interaction tied to the 4.7 `Tween` API and may need re-validation against whatever 4.7 end-state upstream decides to target.

Original fork commit: [`6cbf405`][fork-6cbf405].

[fork-6cbf405]: https://github.com/gtmacdonald/gdzig/commit/6cbf40570117c96dc5629499e7ec6775023fbf8d
[fork-667cc01]: https://github.com/gtmacdonald/gdzig/commit/667cc01c72bba2173035e704231a5ec244bc05cd
