### PR TITLE
fix: Zig 0.16 build & example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .vscode
 .DS_Store
 .zig-cache
+zig-pkg
 zig-out
 gen
 project/lib/

--- a/build.zig
+++ b/build.zig
@@ -159,11 +159,16 @@ pub fn build(b: *Build) !void {
         tests_gdzig_run = b.addRunArtifact(tests_gdzig);
         tests_common_run = b.addRunArtifact(tests_common);
 
-        var tests_dir = try std.fs.cwd().openDir(b.path("test").getPath2(b, null), .{ .iterate = true });
-        defer tests_dir.close();
+        const path = try b.path("test").getPath4(b, null);
+
+        var threaded: std.Io.Threaded = .init_single_threaded;
+        const io = threaded.io();
+
+        var tests_dir = try path.openDir(io, "", .{ .iterate = true });
+        defer tests_dir.close(io);
 
         var iter = tests_dir.iterate();
-        while (iter.next() catch null) |entry| {
+        while (iter.next(io) catch null) |entry| {
             if (entry.kind != .directory) continue;
 
             const test_mod = b.createModule(.{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -6,8 +6,8 @@
 
     .dependencies = .{
         .bbcodez = .{
-            .url = "git+https://github.com/gdzig/bbcodez#5a4f5bd131552e7394ef26b01883370eb422eca4",
-            .hash = "bbcodez-0.0.1-dev-YlrOBo-iAQBWdgFSZ5eINgMNAZlmrHLQ35zKSZEEqgS2",
+            .url = "git+https://github.com/gdzig/bbcodez#7ca97c0738d274195bcb28ab5c789ee0579abbcf",
+            .hash = "bbcodez-0.0.1-dev-YlrOBmyhAQBdGQs5DI8s5xn5nlRg_KQP-aQfCa9eseZp",
         },
         .casez = .{
             .url = "git+https://github.com/gdzig/casez#9732adbfd8c591ddd6e9c3feab016bf9af779d6c",
@@ -19,8 +19,8 @@
             .lazy = true,
         },
         .godot = .{
-            .url = "git+https://github.com/gdzig/godot-versions.git#4f787c5e8765906359911a64d4fb1c8b1ea6c061",
-            .hash = "godot-0.0.0-Nast2tZgBgC6uBE0ft9hVjtKn_BoDWqYo7mQ6BGGZWZf",
+            .url = "git+https://github.com/gdzig/godot-versions#116979cfb99c8e39243bbf46f9e16f43eb6ea6bb",
+            .hash = "godot-0.0.0-Nast2odTBwC2exlCL7BOaBUNmU972XQrTXTy9x9ZA1lO",
         },
         .oopz = .{
             .url = "git+https://github.com/gdzig/oopz#e37ece30bdafc185e88a4bb5d9869115c8d8503f",

--- a/build/api.zig
+++ b/build/api.zig
@@ -98,6 +98,7 @@ fn addExtensionWeb(
 
     mod.pic = true;
     mod.strip = false;
+    mod.addSystemIncludePath(emsdk_path.path(b, "upstream/emscripten/cache/sysroot/include"));
 
     const lib = b.addLibrary(.{
         .linkage = .static,
@@ -115,7 +116,6 @@ fn addExtensionWeb(
     activate_emsdk.step.dependOn(&install_emsdk.step);
 
     lib.step.dependOn(&activate_emsdk.step);
-    lib.addSystemIncludePath(emsdk_path.path(b, "upstream/emscripten/cache/sysroot/include"));
 
     // Run emcc to produce final .wasm
     const optimize = options.optimize;
@@ -219,13 +219,13 @@ pub fn addTestImpl(b: *Build, paths: Resolver, options: TestOptions) *Step.Run {
         .use_llvm = true,
     });
     obj.entry = .disabled;
+    mod.addObject(obj);
 
     const lib = b.addLibrary(.{
         .name = options.name,
         .linkage = .dynamic,
         .root_module = b.createModule(.{ .target = options.target, .optimize = options.optimize }),
     });
-    lib.addObject(obj);
 
     const install_subdir = b.fmt("test/{s}", .{options.name});
     const install_ext = b.addInstallArtifact(lib, .{
@@ -331,7 +331,7 @@ fn getSelfDependency(b: *Build) *Build.Dependency {
 }
 
 fn generateMainScene() []const u8 {
-    return 
+    return
     \\[gd_scene format=3]
     \\
     \\[node name="Main" type="Node"]

--- a/example/build.zig.zon
+++ b/example/build.zig.zon
@@ -7,8 +7,8 @@
             .path = "../",
         },
         .godot = .{
-            .url = "git+https://github.com/gdzig/godot-versions#07c199a34f4c6414afb513026cd1f225f6751913",
-            .hash = "godot-0.0.0-Nast2hpTBgBNoGXh_OiQ50wnJGvOX9kSuDmIRL4Z8Kne",
+            .url = "git+https://github.com/gdzig/godot-versions#116979cfb99c8e39243bbf46f9e16f43eb6ea6bb",
+            .hash = "godot-0.0.0-Nast2odTBwC2exlCL7BOaBUNmU972XQrTXTy9x9ZA1lO",
         },
     },
     .paths = .{

--- a/example/src/SpriteNode.zig
+++ b/example/src/SpriteNode.zig
@@ -46,7 +46,9 @@ pub fn randfRange(self: SpriteNode, comptime T: type, min: T, max: T) T {
 pub fn _ready(self: *SpriteNode) void {
     if (Engine.isEditorHint()) return;
 
-    var prng = std.Random.DefaultPrng.init(@intCast(std.time.timestamp()));
+    var threaded: std.Io.Threaded = .init_single_threaded;
+    const io: std.Io = threaded.io();
+    var prng = std.Random.DefaultPrng.init(@intCast(std.Io.Timestamp.now(io, .awake).nanoseconds));
     self.rng = prng.random();
 
     var logo_path: String = .fromLatin1("res://textures/logo.png");

--- a/pkg/bindgen/Config.zig
+++ b/pkg/bindgen/Config.zig
@@ -6,10 +6,10 @@ const Dir = std.fs.Dir;
 const Config = @This();
 
 arch: Arch,
-extension_api: fs.File,
-gdextension_interface: fs.File,
-input: fs.Dir,
-output: fs.Dir,
+extension_api: std.Io.File,
+gdextension_interface: std.Io.File,
+input: std.Io.Dir,
+output: std.Io.Dir,
 precision: Precision,
 verbosity: Verbosity,
 
@@ -28,16 +28,16 @@ pub const Verbosity = enum {
     verbose,
 };
 
-pub fn loadFromArgs(args: [][:0]u8) !Config {
-    const cwd = std.fs.cwd();
+pub fn loadFromArgs(io: std.Io, args: []const [:0]const u8) !Config {
+    const cwd = std.Io.Dir.cwd();
 
     // args[1]: path to gdextension_interface.h
     // args[2]: path to extension_api.json
-    const gdextension_interface = try cwd.openFile(args[1], .{});
-    const extension_api = try cwd.openFile(args[2], .{});
+    const gdextension_interface = try cwd.openFile(io, args[1], .{});
+    const extension_api = try cwd.openFile(io, args[2], .{});
 
-    const input = try cwd.makeOpenPath(args[3], .{});
-    const output = try cwd.makeOpenPath(args[4], .{});
+    const input = try cwd.createDirPathOpen(io, args[3], .{});
+    const output = try cwd.createDirPathOpen(io, args[4], .{});
 
     const arch = std.meta.stringToEnum(Config.Arch, args[5]) orelse std.debug.panic("Invalid architecture {s}, expected {any}", .{ args[5], std.meta.tags(Config.Arch) });
     const precision = std.meta.stringToEnum(Config.Precision, args[6]) orelse std.debug.panic("Invalid precision {s}, expected {any}", .{ args[6], std.meta.tags(Config.Precision) });
@@ -67,11 +67,11 @@ pub fn buildConfiguration(self: *Config) []const u8 {
     };
 }
 
-pub fn deinit(self: *Config) void {
-    self.gdextension_interface.close();
-    self.extension_api.close();
-    self.input.close();
-    self.output.close();
+pub fn deinit(self: *Config, io: std.Io) void {
+    self.gdextension_interface.close(io);
+    self.extension_api.close(io);
+    self.input.close(io);
+    self.output.close(io);
 }
 
 pub fn testConfig(output: Dir) !Config {

--- a/pkg/bindgen/Context.zig
+++ b/pkg/bindgen/Context.zig
@@ -11,8 +11,8 @@ arena: *ArenaAllocator,
 api: GodotApi,
 config: Config,
 
-all_engine_classes: ArrayList([]const u8) = .empty,
-depends: ArrayList([]const u8) = .empty,
+all_engine_classes: std.ArrayList([]const u8) = .empty,
+depends: std.ArrayList([]const u8) = .empty,
 engine_classes: StringHashMap(bool) = .empty,
 func_docs: StringHashMap([]const u8) = .empty,
 func_names: StringHashMap([]const u8) = .empty,
@@ -48,7 +48,7 @@ const base_type_map = std.StaticStringMap([]const u8).initComptime(.{
     .{ "double", "f64" },
 });
 
-pub fn build(arena: *ArenaAllocator, api: GodotApi, config: Config) !Context {
+pub fn build(arena: *ArenaAllocator, api: GodotApi, config: Config, io: std.Io) !Context {
     var self = Context{
         .arena = arena,
         .api = api,
@@ -57,13 +57,13 @@ pub fn build(arena: *ArenaAllocator, api: GodotApi, config: Config) !Context {
 
     try self.buildSymbolLookupTable();
 
-    try self.parseGdExtensionHeaders();
+    try self.parseGdExtensionHeaders(io);
     try self.parseSingletons();
     try self.parseClasses();
 
     try self.collectSizes();
 
-    try self.castBuiltins();
+    try self.castBuiltins(io);
     try self.castClasses();
     try self.castEnums();
     try self.castFlags();
@@ -212,9 +212,9 @@ fn parseSingletons(self: *Context) !void {
     }
 }
 
-fn parseGdExtensionHeaders(self: *Context) !void {
+fn parseGdExtensionHeaders(self: *Context, io: std.Io) !void {
     var buf: [1024]u8 = undefined;
-    var gdextension_reader = self.config.gdextension_interface.reader(&buf);
+    var gdextension_reader = self.config.gdextension_interface.reader(io, &buf);
     var reader = &gdextension_reader.interface;
 
     const name_doc = "@name";
@@ -223,8 +223,10 @@ fn parseGdExtensionHeaders(self: *Context) !void {
     var fp_type: ?[]const u8 = null;
     const safe_ident_chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_";
 
-    var doc_stream: std.ArrayListUnmanaged(u8) = .empty;
-    const doc_writer: std.ArrayListUnmanaged(u8).Writer = doc_stream.writer(self.allocator());
+    var doc_stream: std.ArrayList(u8) = .empty;
+    var doc_allocating = std.Io.Writer.Allocating.fromArrayList(self.allocator(), &doc_stream);
+    defer doc_allocating.deinit();
+    const doc_writer = &doc_allocating.writer;
 
     var doc_start: ?usize = null;
     var doc_end: ?usize = null;
@@ -232,13 +234,14 @@ fn parseGdExtensionHeaders(self: *Context) !void {
     var doc_line_temp: [1024]u8 = undefined;
 
     while (true) {
-        const line: []const u8 = std.mem.trimRight(u8, (reader.takeDelimiterInclusive('\n') catch break), "\n");
+        const line: []const u8 = std.mem.trimEnd(u8, (reader.takeDelimiterInclusive('\n') catch break), "\n");
 
         const contains_name_doc = std.mem.indexOf(u8, line, name_doc) != null;
 
         // getting function docs
         if (std.mem.indexOf(u8, line, "/*")) |i| if (i >= 0) {
-            doc_start = doc_stream.items.len;
+            doc_start = doc_allocating.written().len;
+            // doc_start = doc_stream.items.len;
 
             if (line.len <= 4) {
                 continue;
@@ -262,10 +265,12 @@ fn parseGdExtensionHeaders(self: *Context) !void {
                 if (!contains_name_doc and !(is_last_line and doc_line.len == 0)) {
                     try doc_writer.writeAll(try self.allocator().dupe(u8, doc_line));
                     try doc_writer.writeAll("\n");
+                    try doc_writer.flush();
                 }
 
                 if (is_last_line) {
-                    doc_end = doc_stream.items.len - 1;
+                    doc_end = doc_allocating.written().len - 1;
+                    // doc_end = doc_stream.items.len - 1;
                 }
             }
         }
@@ -296,7 +301,8 @@ fn parseGdExtensionHeaders(self: *Context) !void {
             const docs: ?[]const u8 = blk: {
                 if (doc_start) |start_index| {
                     if (doc_end) |end_index| {
-                        break :blk try self.allocator().dupe(u8, doc_stream.items[start_index..end_index]);
+                        break :blk try self.allocator().dupe(u8, doc_allocating.written()[start_index..end_index]);
+                        // break :blk try self.allocator().dupe(u8, doc_stream.items[start_index..end_index]);
                     }
                 }
                 break :blk null;
@@ -353,12 +359,12 @@ fn collectSizes(self: *Context) !void {
     }
 }
 
-fn castBuiltins(self: *Context) !void {
+fn castBuiltins(self: *Context, io: std.Io) !void {
     for (self.api.builtin_classes) |api| {
         if (util.shouldSkipClass(api.name)) continue;
 
         var builtin: Builtin = try .fromApi(self.allocator(), api, self);
-        try builtin.loadMixinIfExists(self.allocator(), self.config.input);
+        try builtin.loadMixinIfExists(self.allocator(), self.config.input, io);
 
         try self.builtins.put(self.allocator(), builtin.name_api, builtin);
     }
@@ -428,7 +434,7 @@ fn castModules(self: *Context) !void {
     }
     var i: usize = 0;
     for (self.modules.values()) |*module| {
-        var functions: ArrayList(Function) = .empty;
+        var functions: std.ArrayList(Function) = .empty;
         for (self.api.utility_functions[i..], i..) |function, j| {
             if (!std.mem.eql(u8, module.name, function.category)) {
                 i = j;
@@ -654,7 +660,6 @@ fn parseSinceVersion(docs: ?[]const u8) ?[]const u8 {
 
 const std = @import("std");
 const Allocator = std.mem.Allocator;
-const ArrayList = std.ArrayListUnmanaged;
 const ArenaAllocator = std.heap.ArenaAllocator;
 const StringHashMap = std.StringHashMapUnmanaged;
 const StringArrayHashMap = std.StringArrayHashMapUnmanaged;

--- a/pkg/bindgen/Context/Builtin.zig
+++ b/pkg/bindgen/Context/Builtin.zig
@@ -130,20 +130,20 @@ pub fn fromApi(allocator: Allocator, api: GodotApi.Builtin, ctx: *const Context)
     return self;
 }
 
-pub fn loadMixinIfExists(self: *Builtin, allocator: Allocator, input_dir: std.fs.Dir) !void {
+pub fn loadMixinIfExists(self: *Builtin, allocator: Allocator, input_dir: std.Io.Dir, io: std.Io) !void {
     const mixin_file_path = try std.fmt.allocPrint(allocator, "builtin/{s}.mixin.zig", .{self.name});
     defer allocator.free(mixin_file_path);
 
-    const file = input_dir.openFile(mixin_file_path, .{}) catch |err| {
+    const file = input_dir.openFile(io, mixin_file_path, .{}) catch |err| {
         if (err == error.FileNotFound) return;
         std.log.err("Failed to open mixin file '{s}': {}", .{ mixin_file_path, err });
         return err;
     };
 
     var buf: [4096]u8 = undefined;
-    var file_reader = file.reader(&buf);
+    var file_reader = file.reader(io, &buf);
 
-    const contents = try allocator.allocSentinel(u8, @intCast(try file.getEndPos()), 0);
+    const contents = try allocator.allocSentinel(u8, @intCast(try file.length(io)), 0);
     try file_reader.interface.readSliceAll(contents);
 
     // find the @mixin start/stop markers and only parse that section

--- a/pkg/bindgen/Context/Class.zig
+++ b/pkg/bindgen/Context/Class.zig
@@ -120,9 +120,9 @@ pub fn fromApi(allocator: Allocator, api: GodotApi.Class, ctx: *const Context) !
             inherited.self = switch (inherited.self) {
                 .static => .static,
                 .singleton => .singleton,
-                .constant => |_| .{ .constant = self.name },
-                .mutable => |_| .{ .mutable = self.name },
-                .value => |_| .{ .value = self.name },
+                .constant => .{ .constant = self.name },
+                .mutable => .{ .mutable = self.name },
+                .value => .{ .value = self.name },
             };
 
             // Convert the function to a singleton function if we are a singleton and the parent is not

--- a/pkg/bindgen/Context/docs.zig
+++ b/pkg/bindgen/Context/docs.zig
@@ -49,7 +49,7 @@ pub const DocumentContext = struct {
     current_class: ?[]const u8 = null,
     write_ctx: ?*const WriteContext = null,
     // SAFETY: will be initialized in fromWriteContext
-    writer: *std.io.Writer = undefined,
+    writer: *std.Io.Writer = undefined,
     verbosity: Config.Verbosity = .verbose,
 
     pub fn init(codegen_ctx: *const CodegenContext, current_class: ?[]const u8, symbol_lookup: StringHashMap(Symbol), config: DocumentConfig) DocumentContext {
@@ -252,7 +252,7 @@ pub fn convertDocsToMarkdown(allocator: Allocator, input: []const u8, ctx: *cons
     });
     defer doc.deinit();
 
-    var output: std.io.Writer.Allocating = .init(allocator);
+    var output: std.Io.Writer.Allocating = .init(allocator);
 
     try bbcodez.fmt.md.renderDocument(allocator, doc, &output.writer, .{
         .write_element_fn = writeElement,

--- a/pkg/bindgen/GodotApi.zig
+++ b/pkg/bindgen/GodotApi.zig
@@ -319,5 +319,5 @@ pub fn parseFromReader(arena: *ArenaAllocator, reader: *Reader) !Parsed(GodotApi
 const std = @import("std");
 const ArenaAllocator = std.heap.ArenaAllocator;
 const Parsed = std.json.Parsed;
-const Reader = std.io.Reader;
+const Reader = std.Io.Reader;
 const JsonReader = std.json.Reader;

--- a/pkg/bindgen/codegen.zig
+++ b/pkg/bindgen/codegen.zig
@@ -1,24 +1,24 @@
-pub fn generate(ctx: *Context) !void {
-    try writeBuiltins(ctx);
-    try writeClasses(ctx);
-    try writeGlobals(ctx);
-    try writeDispatchTable(ctx);
-    try writeModules(ctx);
+pub fn generate(ctx: *Context, io: std.Io) !void {
+    try writeBuiltins(ctx, io);
+    try writeClasses(ctx, io);
+    try writeGlobals(ctx, io);
+    try writeDispatchTable(ctx, io);
+    try writeModules(ctx, io);
 }
 
-fn writeBuiltins(ctx: *const Context) !void {
+fn writeBuiltins(ctx: *const Context, io: std.Io) !void {
     var buf: [1024]u8 = undefined;
 
     // builtin.zig
     {
-        const file = try ctx.config.output.createFile("builtin.zig", .{});
-        defer file.close();
+        const file = try ctx.config.output.createFile(io, "builtin.zig", .{});
+        defer file.close(io);
 
-        var file_writer = file.writer(&buf);
+        var file_writer = file.writer(io, &buf);
         var writer = &file_writer.interface;
         var w: CodeWriter = .init(writer);
 
-        try writeMixin(&w, "builtin.mixin.zig", .{}, ctx);
+        try writeMixin(&w, "builtin.mixin.zig", .{}, ctx, io);
 
         // Variant is a special case, since it is not a generated file.
         try w.writeLine(
@@ -42,24 +42,24 @@ fn writeBuiltins(ctx: *const Context) !void {
     }
 
     // builtin/[name].zig
-    try ctx.config.output.makePath("builtin");
+    try ctx.config.output.createDirPath(io, "builtin");
 
     for (ctx.builtins.values()) |*builtin| {
         const filename = try std.fmt.allocPrint(ctx.arena.allocator(), "builtin/{s}.zig", .{builtin.module});
-        const file = try ctx.config.output.createFile(filename, .{});
-        defer file.close();
+        const file = try ctx.config.output.createFile(io, filename, .{});
+        defer file.close(io);
 
-        var file_writer = file.writer(&buf);
+        var file_writer = file.writer(io, &buf);
         var writer = &file_writer.interface;
         var cw = CodeWriter.init(writer);
 
-        try writeBuiltin(&cw, builtin, ctx);
+        try writeBuiltin(&cw, builtin, ctx, io);
 
         try writer.flush();
     }
 }
 
-fn writeBuiltin(w: *CodeWriter, builtin: *const Context.Builtin, ctx: *const Context) !void {
+fn writeBuiltin(w: *CodeWriter, builtin: *const Context.Builtin, ctx: *const Context, io: std.Io) !void {
     try writeDocBlock(w, builtin.doc);
 
     // Declaration start
@@ -143,7 +143,7 @@ fn writeBuiltin(w: *CodeWriter, builtin: *const Context.Builtin, ctx: *const Con
 
     // Enums
     for (builtin.enums.values()) |*@"enum"| {
-        try writeEnum(w, @"enum", ctx);
+        try writeEnum(w, @"enum", ctx, io);
         try w.writeLine("");
     }
 
@@ -162,7 +162,7 @@ fn writeBuiltin(w: *CodeWriter, builtin: *const Context.Builtin, ctx: *const Con
     , .{builtin.name});
 
     // Mixin
-    try writeMixin(w, "builtin/{s}.mixin.zig", .{builtin.name}, ctx);
+    try writeMixin(w, "builtin/{s}.mixin.zig", .{builtin.name}, ctx, io);
 
     // Declaration end
     w.indent -= 1;
@@ -290,19 +290,19 @@ fn writeBuiltinOperator(w: *CodeWriter, builtin_name: []const u8, operator: *con
     , .{operator.name});
 }
 
-fn writeClasses(ctx: *const Context) !void {
+fn writeClasses(ctx: *const Context, io: std.Io) !void {
     var buf: [1024]u8 = undefined;
 
     // class.zig
     {
-        const file = try ctx.config.output.createFile("class.zig", .{});
-        defer file.close();
+        const file = try ctx.config.output.createFile(io, "class.zig", .{});
+        defer file.close(io);
 
-        var file_writer = file.writer(&buf);
+        var file_writer = file.writer(io, &buf);
         var writer = &file_writer.interface;
         var w = CodeWriter.init(writer);
 
-        try writeMixin(&w, "class.mixin.zig", .{}, ctx);
+        try writeMixin(&w, "class.mixin.zig", .{}, ctx, io);
 
         for (ctx.classes.values()) |class| {
             try w.printLine(
@@ -322,25 +322,25 @@ fn writeClasses(ctx: *const Context) !void {
     }
 
     // class/[name].zig
-    try ctx.config.output.makePath("class");
+    try ctx.config.output.createDirPath(io, "class");
     for (ctx.classes.values()) |*class| {
         const filename = try std.fmt.allocPrint(ctx.rawAllocator(), "class/{s}.zig", .{class.module});
         defer ctx.rawAllocator().free(filename);
 
-        const file = try ctx.config.output.createFile(filename, .{});
-        defer file.close();
+        const file = try ctx.config.output.createFile(io, filename, .{});
+        defer file.close(io);
 
-        var file_writer = file.writer(&buf);
+        var file_writer = file.writer(io, &buf);
         var writer = &file_writer.interface;
         var w = CodeWriter.init(writer);
 
-        try writeClass(&w, class, ctx);
+        try writeClass(&w, class, ctx, io);
 
         try writer.flush();
     }
 }
 
-fn writeClass(w: *CodeWriter, class: *const Context.Class, ctx: *const Context) !void {
+fn writeClass(w: *CodeWriter, class: *const Context.Class, ctx: *const Context, io: std.Io) !void {
     try writeDocBlock(w, class.doc);
 
     // Declaration start
@@ -445,13 +445,13 @@ fn writeClass(w: *CodeWriter, class: *const Context.Class, ctx: *const Context) 
 
     // Enums
     for (class.enums.values()) |*@"enum"| {
-        try writeEnum(w, @"enum", ctx);
+        try writeEnum(w, @"enum", ctx, io);
         try w.writeLine("");
     }
 
     // Flags
     for (class.flags.values()) |*flag| {
-        try writeFlag(w, flag, ctx);
+        try writeFlag(w, flag, ctx, io);
         try w.writeLine("");
     }
 
@@ -463,7 +463,7 @@ fn writeClass(w: *CodeWriter, class: *const Context.Class, ctx: *const Context) 
     , .{class.name_api});
 
     // Mixins (include parent class mixins)
-    try writeClassMixins(w, class, ctx);
+    try writeClassMixins(w, class, ctx, io);
 
     // Declaration end
     w.indent -= 1;
@@ -861,19 +861,19 @@ fn writeDocBlock(w: *CodeWriter, docs: ?[]const u8) !void {
     }
 }
 
-fn writeGlobals(ctx: *const Context) !void {
+fn writeGlobals(ctx: *const Context, io: std.Io) !void {
     var buf: [1024]u8 = undefined;
 
     // global.zig
     {
-        const file = try ctx.config.output.createFile("global.zig", .{});
-        defer file.close();
+        const file = try ctx.config.output.createFile(io, "global.zig", .{});
+        defer file.close(io);
 
-        var file_writer = file.writer(&buf);
+        var file_writer = file.writer(io, &buf);
         var writer = &file_writer.interface;
         var w = CodeWriter.init(writer);
 
-        try writeMixin(&w, "global.mixin.zig", .{}, ctx);
+        try writeMixin(&w, "global.mixin.zig", .{}, ctx, io);
 
         for (ctx.enums.values()) |@"enum"| {
             try w.printLine(
@@ -900,19 +900,19 @@ fn writeGlobals(ctx: *const Context) !void {
     }
 
     // global/[name].zig
-    try ctx.config.output.makePath("global");
+    try ctx.config.output.createDirPath(io, "global");
     for (ctx.enums.values()) |*@"enum"| {
         const filename = try std.fmt.allocPrint(ctx.rawAllocator(), "global/{s}.zig", .{@"enum".module});
         defer ctx.rawAllocator().free(filename);
 
-        const file = try ctx.config.output.createFile(filename, .{});
-        defer file.close();
+        const file = try ctx.config.output.createFile(io, filename, .{});
+        defer file.close(io);
 
-        var file_writer = file.writer(&buf);
+        var file_writer = file.writer(io, &buf);
         var writer = &file_writer.interface;
         var w = CodeWriter.init(writer);
 
-        try writeEnum(&w, @"enum", ctx);
+        try writeEnum(&w, @"enum", ctx, io);
 
         try writer.flush();
     }
@@ -921,20 +921,20 @@ fn writeGlobals(ctx: *const Context) !void {
         const filename = try std.fmt.allocPrint(ctx.rawAllocator(), "global/{s}.zig", .{flag.module});
         defer ctx.rawAllocator().free(filename);
 
-        const file = try ctx.config.output.createFile(filename, .{});
-        defer file.close();
+        const file = try ctx.config.output.createFile(io, filename, .{});
+        defer file.close(io);
 
-        var file_writer = file.writer(&buf);
+        var file_writer = file.writer(io, &buf);
         var writer = &file_writer.interface;
         var w = CodeWriter.init(writer);
 
-        try writeFlag(&w, flag, ctx);
+        try writeFlag(&w, flag, ctx, io);
 
         try writer.flush();
     }
 }
 
-fn writeEnum(w: *CodeWriter, @"enum": *const Context.Enum, ctx: *const Context) !void {
+fn writeEnum(w: *CodeWriter, @"enum": *const Context.Enum, ctx: *const Context, io: std.Io) !void {
     try writeDocBlock(w, @"enum".doc);
     try w.printLine("pub const {s} = enum(i32) {{", .{@"enum".name});
     w.indent += 1;
@@ -970,7 +970,7 @@ fn writeEnum(w: *CodeWriter, @"enum": *const Context.Enum, ctx: *const Context) 
         try w.printLine("pub const {s}: @This() = .{s};", .{ alias.name, alias.first_name });
     }
 
-    try writeMixin(w, "global/{s}.mixin.zig", .{@"enum".name}, ctx);
+    try writeMixin(w, "global/{s}.mixin.zig", .{@"enum".name}, ctx, io);
     w.indent -= 1;
     try w.writeLine("};");
 }
@@ -985,7 +985,7 @@ fn writeField(w: *CodeWriter, field: *const Context.Field, class: ?*const Contex
     );
 }
 
-fn writeFlag(w: *CodeWriter, flag: *const Context.Flag, ctx: *const Context) !void {
+fn writeFlag(w: *CodeWriter, flag: *const Context.Flag, ctx: *const Context, io: std.Io) !void {
     try writeDocBlock(w, flag.doc);
     try w.printLine("pub const {s} = packed struct({s}) {{", .{
         flag.name, flag.representation.name(),
@@ -1002,7 +1002,7 @@ fn writeFlag(w: *CodeWriter, flag: *const Context.Flag, ctx: *const Context) !vo
         try writeDocBlock(w, @"const".doc);
         try w.printLine("pub const {s}: {s} = @bitCast(@as({s}, {d}));", .{ @"const".name, flag.name, flag.representation.name(), @"const".value });
     }
-    try writeMixin(w, "global/{s}.mixin.zig", .{flag.module}, ctx);
+    try writeMixin(w, "global/{s}.mixin.zig", .{flag.module}, ctx, io);
     w.indent -= 1;
     try w.writeLine("};");
 }
@@ -1470,22 +1470,22 @@ fn writeImports(w: *CodeWriter, imports: *const Context.Imports, class: ?*const 
 /// Writes mixins for a class and all its parent classes.
 /// Parent mixins are written first (from root to leaf), so child classes
 /// can override or extend parent mixin functionality.
-fn writeClassMixins(w: *CodeWriter, class: *const Context.Class, ctx: *const Context) !void {
+fn writeClassMixins(w: *CodeWriter, class: *const Context.Class, ctx: *const Context, io: std.Io) !void {
     // Recurse to parent first (writes from root to leaf)
     if (class.getBasePtr(ctx)) |parent| {
-        try writeClassMixins(w, parent, ctx);
+        try writeClassMixins(w, parent, ctx, io);
     }
-    try writeMixin(w, "class/{s}.mixin.zig", .{class.name}, ctx);
+    try writeMixin(w, "class/{s}.mixin.zig", .{class.name}, ctx, io);
 }
 
-fn writeMixin(w: *CodeWriter, comptime fmt: []const u8, args: anytype, ctx: *const Context) !void {
+fn writeMixin(w: *CodeWriter, comptime fmt: []const u8, args: anytype, ctx: *const Context, io: std.Io) !void {
     const filename = try std.fmt.allocPrint(ctx.arena.allocator(), fmt, args);
-    const file: ?std.fs.File = ctx.config.input.openFile(filename, .{}) catch null;
+    const file: ?std.Io.File = ctx.config.input.openFile(io, filename, .{}) catch null;
     if (file) |f| {
-        defer f.close();
+        defer f.close(io);
 
         var buf: [1024]u8 = undefined;
-        var file_reader = f.reader(&buf);
+        var file_reader = f.reader(io, &buf);
         var reader = &file_reader.interface;
 
         // Skip lines until we find @mixin start (or copy from beginning if not found)
@@ -1523,13 +1523,13 @@ fn writeMixin(w: *CodeWriter, comptime fmt: []const u8, args: anytype, ctx: *con
     }
 }
 
-fn writeDispatchTable(ctx: *Context) !void {
+fn writeDispatchTable(ctx: *Context, io: std.Io) !void {
     var buf: [1024]u8 = undefined;
 
-    const file = try ctx.config.output.createFile("DispatchTable.zig", .{});
-    defer file.close();
+    const file = try ctx.config.output.createFile(io, "DispatchTable.zig", .{});
+    defer file.close(io);
 
-    var file_writer = file.writer(&buf);
+    var file_writer = file.writer(io, &buf);
     var writer = &file_writer.interface;
     var w = CodeWriter.init(writer);
 
@@ -1603,31 +1603,31 @@ fn writeDispatchTable(ctx: *Context) !void {
     );
 
     try writer.flush();
-    try file.sync();
+    try file.sync(io);
 }
 
-fn writeModules(ctx: *const Context) !void {
+fn writeModules(ctx: *const Context, io: std.Io) !void {
     var buf: [1024]u8 = undefined;
 
     for (ctx.modules.values()) |*module| {
         const filename = try std.fmt.allocPrint(ctx.rawAllocator(), "{s}.zig", .{module.name});
         defer ctx.rawAllocator().free(filename);
 
-        const file = try ctx.config.output.createFile(filename, .{});
-        defer file.close();
+        const file = try ctx.config.output.createFile(io, filename, .{});
+        defer file.close(io);
 
-        var file_writer = file.writer(&buf);
+        var file_writer = file.writer(io, &buf);
         var writer = &file_writer.interface;
         var w = CodeWriter.init(writer);
 
-        try writeModule(&w, module, ctx);
+        try writeModule(&w, module, ctx, io);
 
         try writer.flush();
     }
 }
 
-fn writeModule(w: *CodeWriter, module: *const Context.Module, ctx: *const Context) !void {
-    try writeMixin(w, "{s}.mixin.zig", .{module.name}, ctx);
+fn writeModule(w: *CodeWriter, module: *const Context.Module, ctx: *const Context, io: std.Io) !void {
+    try writeMixin(w, "{s}.mixin.zig", .{module.name}, ctx, io);
 
     for (module.functions) |*function| {
         if (function.skip) continue;

--- a/pkg/bindgen/main.zig
+++ b/pkg/bindgen/main.zig
@@ -13,7 +13,7 @@ pub const std_options: std.Options = .{
 
 fn logFn(
     comptime level: std.log.Level,
-    comptime scope: @Type(.enum_literal),
+    comptime scope: @EnumLiteral(),
     comptime format: []const u8,
     args: anytype,
 ) void {
@@ -22,54 +22,48 @@ fn logFn(
     std.log.defaultLog(level, scope, format, args);
 }
 
-pub fn main() !void {
-    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
-    defer arena.deinit();
-
-    const allocator = arena.allocator();
-
-    const args = try std.process.argsAlloc(allocator);
-    defer std.process.argsFree(allocator, args);
-
+pub fn main(init: std.process.Init) !void {
+    const arena = init.arena.allocator();
+    const args = try init.minimal.args.toSlice(arena);
     if (args.len < 6) {
         std.debug.print("Usage: bindgen <gdextension_interface.h> <extension_api.json> <mixins_root> <output_path> <float|double> <32|64> <quiet|verbose>\n", .{});
         return;
     }
 
     // Assemble the bindgen configuration
-    var config = try Config.loadFromArgs(args);
-    defer config.deinit();
+    var config = try Config.loadFromArgs(init.io, args);
+    defer config.deinit(init.io);
 
     verbose = config.verbosity == .verbose;
 
     var buf: [4096]u8 = undefined;
-    var reader = config.extension_api.reader(&buf);
+    var reader = config.extension_api.reader(init.io, &buf);
 
     // Parse the extension_api.json
-    const parser_start = std.time.nanoTimestamp();
-    const godot_api = try GodotApi.parseFromReader(&arena, &reader.interface);
+    const parser_start = std.Io.Timestamp.now(init.io, .awake);
+    const godot_api = try GodotApi.parseFromReader(init.arena, &reader.interface);
     defer godot_api.deinit();
-    const parser_time = std.time.nanoTimestamp() - parser_start;
+    const context_start = std.Io.Timestamp.now(init.io, .awake);
+    const parser_time = parser_start.durationTo(context_start).nanoseconds;
 
     // Build the codegen context
-    const context_start = std.time.nanoTimestamp();
-    var ctx = try Context.build(&arena, godot_api.value, config);
-    const context_time = std.time.nanoTimestamp() - context_start;
+    var ctx = try Context.build(init.arena, godot_api.value, config, init.io);
+    const codegen_start = std.Io.Timestamp.now(init.io, .awake);
+    const context_time = context_start.durationTo(codegen_start).nanoseconds;
 
     // Generate the code
-    const codegen_start = std.time.nanoTimestamp();
-    try codegen.generate(&ctx);
-    const codegen_time = std.time.nanoTimestamp() - codegen_start;
+    try codegen.generate(&ctx, init.io);
+    const format_start = std.Io.Timestamp.now(init.io, .awake);
+    const codegen_time = codegen_start.durationTo(codegen_start).nanoseconds;
 
     // Format the code
-    const format_start = std.time.nanoTimestamp();
-    _ = try std.process.Child.run(.{
-        .allocator = allocator,
-        .cwd_dir = config.output,
+    _ = try std.process.run(arena, init.io, .{
+        .cwd = .{ .dir = config.output },
         .argv = &.{ "zig", "fmt" },
-        .max_output_bytes = 1024 * 1024,
+        .stderr_limit = .limited(1024 * 1024),
+        .stdout_limit = .limited(1024 * 1024),
     });
-    const format_time = std.time.nanoTimestamp() - format_start;
+    const format_time = format_start.durationTo(std.Io.Timestamp.now(init.io, .awake)).nanoseconds;
 
     if (config.verbosity == .verbose) {
         if (config.verbosity == .verbose) {

--- a/pkg/common/common.zig
+++ b/pkg/common/common.zig
@@ -48,7 +48,7 @@ const dictionary: Config.Dictionary = .{
 /// Format helper for use with std.fmt
 pub fn Fmt(comptime config: Config) type {
     return struct {
-        pub fn format(str: []const u8, writer: *std.io.Writer) std.io.Writer.Error!void {
+        pub fn format(str: []const u8, writer: *std.Io.Writer) std.Io.Writer.Error!void {
             var buf: [256]u8 = undefined;
             const result = casez.bufConvert(&buf, config, str) catch return error.WriteFailed;
             try writer.writeAll(result);

--- a/src/extension/Registry.zig
+++ b/src/extension/Registry.zig
@@ -2,15 +2,15 @@ const Registry = @This();
 
 allocator: Allocator,
 arena: ArenaAllocator,
-classes: std.ArrayListUnmanaged(*AnyClass),
-callbacks: std.ArrayListUnmanaged(*AnyCallbacks),
+classes: std.ArrayList(*AnyClass),
+callbacks: std.ArrayList(*AnyCallbacks),
 
 pub fn init(backing_allocator: Allocator) Registry {
     return .{
         .allocator = backing_allocator,
         .arena = .init(backing_allocator),
-        .classes = .{},
-        .callbacks = .{},
+        .classes = .empty,
+        .callbacks = .empty,
     };
 }
 
@@ -139,11 +139,11 @@ pub fn Class(comptime T: type) type {
         registry: *Registry,
         userdata: class_mod.ClassUserdataOf(T),
 
-        methods: std.ArrayListUnmanaged(*Method(T)),
-        signals: std.ArrayListUnmanaged(*AnySignal),
-        groups: std.ArrayListUnmanaged(*Group(T)),
-        ungrouped_properties: std.ArrayListUnmanaged(*AnyProperty),
-        constants: std.ArrayListUnmanaged(Constant),
+        methods: std.ArrayList(*Method(T)),
+        signals: std.ArrayList(*AnySignal),
+        groups: std.ArrayList(*Group(T)),
+        ungrouped_properties: std.ArrayList(*AnyProperty),
+        constants: std.ArrayList(Constant),
 
         /// Initialization level for this class. Default is `.scene`.
         level: InitializationLevel,
@@ -165,11 +165,11 @@ pub fn Class(comptime T: type) type {
                 },
                 .registry = registry,
                 .userdata = userdata,
-                .methods = .{},
-                .signals = .{},
-                .groups = .{},
-                .ungrouped_properties = .{},
-                .constants = .{},
+                .methods = .empty,
+                .signals = .empty,
+                .groups = .empty,
+                .ungrouped_properties = .empty,
+                .constants = .empty,
                 .level = options.level,
                 .is_virtual = options.is_virtual,
                 .is_abstract = options.is_abstract,
@@ -562,7 +562,7 @@ pub fn Property(comptime T: type, comptime name: [:0]const u8) type {
         /// Resolve getter/setter methods (may create new methods for auto-detection).
         fn doResolve(any: *AnyProperty, methods_opaque: *anyopaque) void {
             const self: *Self = @alignCast(@fieldParentPtr("any", any));
-            const methods: *std.ArrayListUnmanaged(*Method(T)) = @ptrCast(@alignCast(methods_opaque));
+            const methods: *std.ArrayList(*Method(T)) = @ptrCast(@alignCast(methods_opaque));
             const alloc = self.class.allocator();
 
             // Indexed properties cannot use auto-detection
@@ -626,7 +626,7 @@ pub fn Property(comptime T: type, comptime name: [:0]const u8) type {
         fn resolveGetter(
             getter: Accessor(T),
             alloc: Allocator,
-            methods: *std.ArrayListUnmanaged(*Method(T)),
+            methods: *std.ArrayList(*Method(T)),
         ) ?*const Method(T) {
             return switch (getter) {
                 .auto => if (can_auto_getter) autoDetectGetter(alloc, methods) else unreachable,
@@ -638,7 +638,7 @@ pub fn Property(comptime T: type, comptime name: [:0]const u8) type {
         fn resolveSetter(
             setter: Accessor(T),
             alloc: Allocator,
-            methods: *std.ArrayListUnmanaged(*Method(T)),
+            methods: *std.ArrayList(*Method(T)),
         ) ?*const Method(T) {
             return switch (setter) {
                 .auto => if (can_auto_setter) autoDetectSetter(alloc, methods) else unreachable,
@@ -649,7 +649,7 @@ pub fn Property(comptime T: type, comptime name: [:0]const u8) type {
 
         fn autoDetectGetter(
             alloc: Allocator,
-            methods: *std.ArrayListUnmanaged(*Method(T)),
+            methods: *std.ArrayList(*Method(T)),
         ) *const Method(T) {
             // Auto-detect: check for getX method, then field
             if (@hasDecl(T, getter_decl)) {
@@ -672,7 +672,7 @@ pub fn Property(comptime T: type, comptime name: [:0]const u8) type {
 
         fn autoDetectSetter(
             alloc: Allocator,
-            methods: *std.ArrayListUnmanaged(*Method(T)),
+            methods: *std.ArrayList(*Method(T)),
         ) *const Method(T) {
             // Auto-detect: check for setX method, then field
             if (@hasDecl(T, setter_decl)) {
@@ -751,13 +751,13 @@ pub fn Group(comptime T: type) type {
 
         class: *Class(T),
         name: [:0]const u8,
-        entries: std.ArrayListUnmanaged(Entry),
+        entries: std.ArrayList(Entry),
 
         pub fn init(class: *Class(T), name: [:0]const u8) Self {
             return .{
                 .class = class,
                 .name = name,
-                .entries = .{},
+                .entries = .empty,
             };
         }
 
@@ -825,7 +825,7 @@ pub fn Subgroup(comptime T: type) type {
 
         class: *Class(T),
         name: [:0]const u8,
-        properties: std.ArrayListUnmanaged(*AnyProperty),
+        properties: std.ArrayList(*AnyProperty),
 
         pub fn init(class: *Class(T), subgroup_name: [:0]const u8) Self {
             return .{

--- a/src/extension/class.zig
+++ b/src/extension/class.zig
@@ -76,7 +76,7 @@ pub const PropertyListInstanceBinding = struct {
 
     var gpa: GeneralPurposeAllocator = .init;
     const allocator = gpa.allocator();
-    var pool: MemoryPool(PropertyListInstanceBinding) = .init(allocator);
+    var pool: MemoryPool(PropertyListInstanceBinding) = .empty;
 
     pub const callbacks: c.GDExtensionInstanceBindingCallbacks = .{
         .create_callback = &create,
@@ -84,7 +84,7 @@ pub const PropertyListInstanceBinding = struct {
     };
 
     fn create(_: ?*anyopaque, _: ?*anyopaque) callconv(.c) ?*anyopaque {
-        return @ptrCast(pool.create() catch return null);
+        return @ptrCast(pool.create(allocator) catch return null);
     }
 
     fn free(_: ?*anyopaque, _: ?*anyopaque, binding: ?*anyopaque) callconv(.c) void {
@@ -92,7 +92,7 @@ pub const PropertyListInstanceBinding = struct {
     }
 
     pub fn cleanup() void {
-        pool.deinit();
+        pool.deinit(allocator);
         assert(gpa.deinit() == .ok);
     }
 };
@@ -104,7 +104,7 @@ pub const DestroyInstanceBinding = struct {
 
     var gpa: GeneralPurposeAllocator = .init;
     const allocator = gpa.allocator();
-    var pool: MemoryPool(PropertyListInstanceBinding) = .init(allocator);
+    var pool: MemoryPool(PropertyListInstanceBinding) = .empty;
 
     pub const callbacks: c.GDExtensionInstanceBindingCallbacks = .{
         .create_callback = &create,
@@ -112,7 +112,7 @@ pub const DestroyInstanceBinding = struct {
     };
 
     fn create(_: ?*anyopaque, _: ?*anyopaque) callconv(.c) ?*anyopaque {
-        return @ptrCast(pool.create() catch return null);
+        return @ptrCast(pool.create(allocator) catch return null);
     }
 
     fn free(_: ?*anyopaque, _: ?*anyopaque, binding: ?*anyopaque) callconv(.c) void {
@@ -125,7 +125,7 @@ pub const DestroyInstanceBinding = struct {
     }
 
     pub fn cleanup() void {
-        pool.deinit();
+        pool.deinit(allocator);
         assert(gpa.deinit() == .ok);
     }
 };


### PR DESCRIPTION
I wanted to get the Zig binding example working so I spent a bit of time figuring out how to build it.

**WARNING** this is just a first pass, I merely replaced calls that work with Zig 0.16, but I don't know if I introduced any leaks or any unwanted behavior since I went through it just concerned about the syntax more than anything.

In other words, the PR definitely needs a review and a bit of testing.

---

The only thing I didn't figure out how to do is, when building the example, `gdextension_interface.h` & related files are searched in the local folder (i.e. `gdzig/example/.zig-cache`), but the files are generated only in the root `gdzig/.zig-cache` respective folder.

To make the example build, I had to manually copy the files from the parent `gdzig/.zig-cache` folder into `gdzig/example/.zig-cache`.

----

Other than that `gdzig` (the root folder) build seems to do its job, and I tested the example as well (after copying the files as mentioned before).

I only tested `zig build` with the pinned Godot 4.6 version, I'm sure it needs update for >4.6, cause the API changed, but that's a bit above my pay grade :)

---

I haven't updated the tests yet, those probably require some updating for Zig 0.16 as well.


https://github.com/user-attachments/assets/49a4f727-0d1d-40e2-9d00-5bb3472d59b7

