### PR TITLE
fix(bindings): release varcall return ownership + nullable object marshalling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,3 +35,6 @@
 - **Type introspection**: `godot.meta` module provides runtime type hierarchy inspection
 - **Flexible header options**: Choose between generated, vendored, or custom headers
 - **Improved bindgen**: Completely rewritten and more robust code generation that allowed us to implement all of the above
+- **Fixed varcall return ownership**: A bound method returning a builtin (`Array`, `Dictionary`, `String`, etc.) now transfers ownership to the caller on both the `ptrcall` and `varcall` entry points; previously `varcall` copied the value into a `Variant` and leaked the callee's local
+  - **Breaking**: if your method returned a *borrowed* builtin (one whose handle you kept and reused), that call was only correct on `varcall` before — it is now a double-free. Return a fresh copy instead of a borrowed handle
+  - Full return contract: builtin returns are moved/adopted by the caller on both paths; `*RefCounted` object returns are borrowed on both paths (`Variant`/`varcall` and `ptrcall` both take their own reference for the caller, so the callee's is untouched)

--- a/build/api.zig
+++ b/build/api.zig
@@ -363,13 +363,15 @@ fn generateGdextension(b: *Build, lib_name: []const u8) []const u8 {
         \\[libraries]
         \\linux.debug.x86_64 = "res://{s}"
         \\linux.release.x86_64 = "res://{s}"
+        \\linux.debug.arm64 = "res://{s}"
+        \\linux.release.arm64 = "res://{s}"
         \\windows.debug.x86_64 = "res://{s}"
         \\windows.release.x86_64 = "res://{s}"
         \\macos.debug.arm64 = "res://{s}"
         \\macos.release.arm64 = "res://{s}"
         \\macos.debug.x86_64 = "res://{s}"
         \\macos.release.x86_64 = "res://{s}"
-    , .{ lib_name, lib_name, lib_name, lib_name, lib_name, lib_name, lib_name, lib_name });
+    , .{ lib_name, lib_name, lib_name, lib_name, lib_name, lib_name, lib_name, lib_name, lib_name, lib_name });
 }
 
 const std = @import("std");

--- a/src/builtin/variant.zig
+++ b/src/builtin/variant.zig
@@ -22,13 +22,18 @@ pub const Variant = extern struct {
         const tag = comptime Tag.forType(T);
 
         if (tag == .object) {
+            const Ptr = class.ClassPtrOf(T);
+            const object_value: Ptr = if (comptime class.isNullableClassPtr(T))
+                value orelse return .nil
+            else
+                value;
             // For RefCounted objects, manually construct the Variant and call reference()
             // to share ownership. We bypass variantFromType because it uses init_ref()
             // which only works correctly for first-time ownership transfer.
             if (comptime class.isRefCountedPtr(T)) {
-                _ = RefCounted.upcast(value).reference();
+                _ = RefCounted.upcast(object_value).reference();
             }
-            const obj = Object.upcast(value);
+            const obj = Object.upcast(object_value);
             return .{
                 .tag = .object,
                 .data = .{
@@ -65,6 +70,9 @@ pub const Variant = extern struct {
     /// Calling `deinit` on the returned value is illegal behavior.
     pub fn wrap(comptime T: type, value: *const T) Variant {
         const tag = comptime Tag.forType(T);
+        if (comptime class.isNullableClassPtr(T)) {
+            if (value.* == null) return .nil;
+        }
         return .{
             .tag = tag,
             .data = switch (tag) {
@@ -103,8 +111,8 @@ pub const Variant = extern struct {
                 // Object
                 .object => .{
                     .object = .{
-                        .id = @enumFromInt(Object.upcast(value.*).getInstanceId()),
-                        .object = Object.upcast(value.*),
+                        .id = @enumFromInt(Object.upcast(if (comptime class.isNullableClassPtr(T)) value.*.? else value.*).getInstanceId()),
+                        .object = Object.upcast(if (comptime class.isNullableClassPtr(T)) value.*.? else value.*),
                     },
                 },
 
@@ -137,6 +145,10 @@ pub const Variant = extern struct {
     pub fn as(self: Variant, comptime T: type) ?T {
         const tag = comptime Tag.forType(T);
 
+        if (comptime class.isNullableClassPtr(T)) {
+            if (self.tag == .nil) return @as(T, null);
+        }
+
         if (!self.isCompatibleCast(tag)) {
             return null;
         }
@@ -150,13 +162,19 @@ pub const Variant = extern struct {
         } else {
             var object: ?*Object = null;
             variantToType(@ptrCast(&object), @ptrCast(@constCast(&self)));
-            if (object == null) return null;
-            if (comptime class.isOpaqueClassPtr(T)) {
-                return @ptrCast(@alignCast(object));
+            if (object == null) {
+                if (comptime class.isNullableClassPtr(T)) return @as(T, null);
+                return null;
+            }
+            const Ptr = class.ClassPtrOf(T);
+            if (comptime class.isOpaqueClassPtr(Ptr)) {
+                const result: Ptr = @ptrCast(@alignCast(object));
+                return @as(T, result);
             } else {
-                const Base = class.BaseOf(Child(T));
+                const Base = class.BaseOf(Child(Ptr));
                 const base: *Base = @ptrCast(object);
-                return base.asInstance(Child(T));
+                const result = base.asInstance(Child(Ptr)) orelse return null;
+                return @as(T, result);
             }
         }
     }
@@ -586,6 +604,7 @@ pub const Variant = extern struct {
                         .@"enum" => .int,
                         .@"struct" => |info| if (info.backing_integer != null) .int else null,
                         .pointer => |p| if (class.isClassPtr(T)) .object else forType(p.child),
+                        .optional => |info| if (class.isClassPtr(info.child)) .object else null,
                         else => null,
                     };
                 },

--- a/src/class.mixin.zig
+++ b/src/class.mixin.zig
@@ -29,8 +29,28 @@ pub fn isRefCounted(comptime T: type) bool {
 ///
 /// Expects a pointer type, e.g. `*Node` or `*MyClass`, not `Node` or `MyClass`.
 pub fn isRefCountedPtr(comptime T: type) bool {
-    if (@typeInfo(T) != .pointer) return false;
-    return isRefCounted(std.meta.Child(T));
+    const Pointer = switch (@typeInfo(T)) {
+        .optional => |info| info.child,
+        else => T,
+    };
+    if (@typeInfo(Pointer) != .pointer) return false;
+    return isRefCounted(std.meta.Child(Pointer));
+}
+
+/// Returns true when `T` is an optional whose payload is a Godot class
+/// pointer, such as `?*Node` or `?*MyResource`.
+pub fn isNullableClassPtr(comptime T: type) bool {
+    return switch (@typeInfo(T)) {
+        .optional => |info| isClassPtr(info.child),
+        else => false,
+    };
+}
+
+/// Returns the non-optional class pointer carried by `T`.
+pub fn ClassPtrOf(comptime T: type) type {
+    if (isNullableClassPtr(T)) return @typeInfo(T).optional.child;
+    if (isClassPtr(T)) return T;
+    @compileError("expected a Godot class pointer, found '" ++ @typeName(T) ++ "'");
 }
 
 /// Downcast a value to a child type in the class hierarchy. Has some compile time checks, but returns null at runtime if the cast fails.

--- a/src/extension.zig
+++ b/src/extension.zig
@@ -12,6 +12,11 @@ pub const InitializationLevel = enum(c_int) {
 
 pub const Registry = @import("extension/Registry.zig");
 
+/// Low-level registration pieces exposed for binding integration tests.
+pub const testing = struct {
+    pub const MethodConfig = @import("extension/method.zig").MethodConfig;
+};
+
 const class = @import("extension/class.zig");
 pub const DestroyInstanceBinding = class.DestroyInstanceBinding;
 pub const PropertyListInstanceBinding = class.PropertyListInstanceBinding;

--- a/src/extension/method.zig
+++ b/src/extension/method.zig
@@ -117,19 +117,8 @@ pub fn MethodConfig(comptime Class: type) type {
                     } else {
                         const result = @call(.auto, method, call_args);
                         if (ret) |r| {
-                            ptrcall.writeReturn(ReturnType, r, result);
+                            writePtrReturn(ReturnType, r, result);
                         }
-                    }
-                }
-
-                fn ptrToArg(comptime ArgType: type, p_arg: *const anyopaque) ArgType {
-                    if (comptime class.isRefCountedPtr(ArgType) and class.isOpaqueClassPtr(ArgType)) {
-                        const obj = gdzig.raw.refGetObject(@ptrCast(p_arg));
-                        return @ptrCast(obj.?);
-                    } else if (comptime class.isOpaqueClassPtr(ArgType)) {
-                        return @ptrCast(@constCast(p_arg));
-                    } else {
-                        return ptrcall.readArg(ArgType, p_arg);
                     }
                 }
             };
@@ -162,7 +151,7 @@ pub fn MethodConfig(comptime Class: type) type {
 
                 fn ptrCall(instance: *Class, _: [*]const *const anyopaque, ret: ?*anyopaque) void {
                     if (ret) |r| {
-                        ptrcall.writeReturn(FieldType, r, @field(instance, field_name));
+                        writePtrReturn(FieldType, r, @field(instance, field_name));
                     }
                 }
             };
@@ -194,7 +183,7 @@ pub fn MethodConfig(comptime Class: type) type {
                 }
 
                 fn ptrCall(instance: *Class, args: [*]const *const anyopaque, _: ?*anyopaque) void {
-                    @field(instance, field_name) = ptrcall.readArg(FieldType, args[0]);
+                    @field(instance, field_name) = ptrToArg(FieldType, args[0]);
                 }
             };
 
@@ -207,4 +196,47 @@ pub fn MethodConfig(comptime Class: type) type {
             };
         }
     };
+}
+
+/// Decode one extension-method ptrcall argument. RefCounted values travel
+/// through Godot's Ref ABI, including extension classes and nullable Refs;
+/// their slot is not the raw object pointer represented by the Zig type.
+fn ptrToArg(comptime ArgType: type, p_arg: *const anyopaque) ArgType {
+    if (comptime class.isRefCountedPtr(ArgType)) {
+        const Ptr = class.ClassPtrOf(ArgType);
+        const object = gdzig.raw.refGetObject(@ptrCast(p_arg)) orelse {
+            if (comptime class.isNullableClassPtr(ArgType)) return null;
+            @panic("non-null RefCounted ptrcall argument contained a null Ref");
+        };
+
+        const value: Ptr = if (comptime class.isOpaqueClassPtr(Ptr))
+            @ptrCast(@alignCast(object))
+        else blk: {
+            const Class = std.meta.Child(Ptr);
+            const Base = class.BaseOf(Class);
+            const base: *Base = @ptrCast(@alignCast(object));
+            break :blk base.asInstance(Class) orelse @panic("Ref ptrcall argument has the wrong extension class");
+        };
+        return @as(ArgType, value);
+    }
+
+    if (comptime class.isOpaqueClassPtr(ArgType)) {
+        return @ptrCast(@constCast(p_arg));
+    }
+    return ptrcall.readArg(ArgType, p_arg);
+}
+
+/// Encode one extension-method ptrcall return. Godot supplies storage for a
+/// Ref wrapper when the declared type is RefCounted, so populate that wrapper
+/// instead of writing the Zig object pointer directly into it.
+fn writePtrReturn(comptime ReturnType: type, p_ret: *anyopaque, value: ReturnType) void {
+    if (comptime class.isRefCountedPtr(ReturnType)) {
+        const object: ?*gdzig.class.Object = if (comptime class.isNullableClassPtr(ReturnType))
+            if (value) |object_value| .upcast(object_value) else null
+        else
+            .upcast(value);
+        gdzig.raw.refSetObject(@ptrCast(p_ret), if (object) |obj| @ptrCast(obj) else null);
+        return;
+    }
+    ptrcall.writeReturn(ReturnType, p_ret, value);
 }

--- a/src/extension/method.zig
+++ b/src/extension/method.zig
@@ -101,7 +101,9 @@ pub fn MethodConfig(comptime Class: type) type {
                         return Variant.nil;
                     } else {
                         const result = @call(.auto, method, call_args);
-                        return Variant.init(ReturnType, result);
+                        const variant = Variant.init(ReturnType, result);
+                        releaseVarReturn(ReturnType, result);
+                        return variant;
                     }
                 }
 
@@ -239,4 +241,40 @@ fn writePtrReturn(comptime ReturnType: type, p_ret: *anyopaque, value: ReturnTyp
         return;
     }
     ptrcall.writeReturn(ReturnType, p_ret, value);
+}
+
+/// Drop the callee's own reference to a value it just returned through the varcall path, so
+/// that both entry points registered for a bound method agree on who owns the return value.
+///
+/// `ptrcall` sets the convention for builtins: `ptrcall.writeReturn` writes the struct into
+/// the engine's return slot bitwise, which is a move — ownership transfers to the caller and
+/// the callee's local is dead afterwards. `varcall` cannot move, because `Variant.init` goes
+/// through Godot's copy constructor and takes a reference of its own. Without this call the
+/// callee's reference is never dropped, so a method returning a freshly built `Array` leaks
+/// it on `varcall` while being correct on `ptrcall`, and a method returning a borrowed one is
+/// a use-after-free on `ptrcall` — no return value is correct on both paths.
+///
+/// Only builtins with a Godot destructor are released. Godot reports that through
+/// `has_destructor`, and bindgen emits `deinit` exactly for those, so `@hasDecl` is the
+/// type-driven form of that flag: `Array`, `Dictionary`, `String`, `StringName`, `NodePath`,
+/// `Callable`, `Signal` and the `Packed*Array` family have one; `Vector2`, `Color`, `Rect2`,
+/// `Transform3d`, `Basis`, `Projection`, `Aabb` and friends do not. Restricting to structs
+/// keeps `@hasDecl` off scalars, enums and pointers, where it would not compile.
+///
+/// Object pointers are deliberately *not* released. Both paths already agree on them:
+/// `writePtrReturn` hands a RefCounted return to `refSetObject`, which calls Godot's
+/// `reference_ptr` and takes a reference for the caller, exactly as `Variant.init` does. They
+/// are both copies, so releasing here would leave the caller holding the only reference to an
+/// object the callee still believes it owns. Non-refcounted object pointers are never
+/// referenced by either path and own nothing.
+///
+/// `Variant` itself has a `deinit` and would match the struct-with-`deinit` predicate below, but
+/// it is unreachable as a `ReturnType` today because `Variant.Tag.forType` has no `Variant` case
+/// and `@compileError`s first. If a pass-through `Variant` return is ever added, releasing it
+/// here would double-free: exempt it explicitly, or re-derive its ownership from scratch.
+fn releaseVarReturn(comptime ReturnType: type, value: ReturnType) void {
+    if (comptime @typeInfo(ReturnType) == .@"struct" and @hasDecl(ReturnType, "deinit")) {
+        var owned: ReturnType = value;
+        owned.deinit();
+    }
 }

--- a/test/leaks/root.zig
+++ b/test/leaks/root.zig
@@ -92,6 +92,45 @@ const RefReturnNode = struct {
     }
 };
 
+test "varcall adopts a builtin return value" {
+    const Returner = struct {
+        payload: *RefCounted,
+
+        /// Builds a fresh `Array` holding one reference to `payload` and hands
+        /// ownership of it to the caller, the way `ptrcall` already expects.
+        pub fn makeArray(self: *@This()) Array {
+            var array = Array.init();
+            const boxed = Variant.init(*RefCounted, self.payload);
+            defer boxed.deinit();
+            array.append(boxed);
+            return array;
+        }
+    };
+
+    const object = RefCounted.init();
+    try testing.expectEqual(@as(i32, 1), object.getReferenceCount());
+
+    var returner: Returner = .{ .payload = object };
+    const config = gdzig.extension.testing.MethodConfig(Returner).fromName("make_array", "makeArray", .{});
+
+    const no_args: []const *const Variant = &.{};
+    const variant = try config.call.?(&returner, no_args);
+
+    // The Array now inside the Variant holds the only reference to `object`
+    // besides our own.
+    try testing.expectEqual(@as(i32, 2), object.getReferenceCount());
+
+    // Destroying the Variant has to destroy that Array, which it can only do if
+    // `call` released the callee's own handle after boxing it. `Variant.init`
+    // copies rather than moves, so without that release the Array outlives the
+    // Variant and keeps `object` referenced forever.
+    variant.deinit();
+    try testing.expectEqual(@as(i32, 1), object.getReferenceCount());
+
+    try testing.expect(object.unreference());
+    object.destroy();
+}
+
 const std = @import("std");
 const testing = std.testing;
 
@@ -100,6 +139,7 @@ const general = gdzig.general;
 const allocator = gdzig.testing.allocator;
 const Node = gdzig.class.Node;
 const Object = gdzig.class.Object;
+const Array = gdzig.builtin.Array;
 const RefCounted = gdzig.class.RefCounted;
 const Resource = gdzig.class.Resource;
 const ResourceSaver = gdzig.class.ResourceSaver;

--- a/test/nullable_object_method/root.zig
+++ b/test/nullable_object_method/root.zig
@@ -1,0 +1,73 @@
+pub fn register(r: *gdzig.extension.Registry) void {
+    const class = r.createClass(NullableObjectNode, {}, .auto);
+    class.addMethod("accept_node", .auto);
+    class.addMethod("null_node", .auto);
+}
+
+fn ensureRegistered() void {
+    const State = struct {
+        var done = false;
+    };
+    if (!State.done) {
+        State.done = true;
+        gdzig.testing.loadModule(@This());
+    }
+}
+
+test "bound methods accept and return nullable object pointers" {
+    ensureRegistered();
+
+    const receiver = try NullableObjectNode.create();
+    defer receiver.base.destroy();
+
+    const rejected = Object.call(.upcast(receiver), .fromComptimeLatin1("accept_node"), .{@as(?*Node, null)});
+    defer rejected.deinit();
+    try testing.expect(!rejected.as(bool).?);
+
+    const node = Node.init();
+    defer node.destroy();
+    const accepted = Object.call(.upcast(receiver), .fromComptimeLatin1("accept_node"), .{@as(?*Node, node)});
+    defer accepted.deinit();
+    try testing.expect(accepted.as(bool).?);
+
+    const returned = Object.call(.upcast(receiver), .fromComptimeLatin1("null_node"), .{});
+    defer returned.deinit();
+    try testing.expectEqual(Variant.Tag.nil, returned.tag);
+    const nullable = returned.as(?*Node);
+    try testing.expect(nullable != null);
+    try testing.expect(nullable.? == null);
+}
+
+const NullableObjectNode = struct {
+    base: *Node,
+
+    pub fn create() !*NullableObjectNode {
+        const self = try allocator.create(NullableObjectNode);
+        self.* = .{ .base = .init() };
+        self.base.setInstance(NullableObjectNode, self);
+        return self;
+    }
+
+    pub fn destroy(self: *NullableObjectNode) void {
+        allocator.destroy(self);
+    }
+
+    pub fn acceptNode(self: *NullableObjectNode, node: ?*Node) bool {
+        _ = self;
+        return node != null;
+    }
+
+    pub fn nullNode(self: *NullableObjectNode) ?*Node {
+        _ = self;
+        return null;
+    }
+};
+
+const std = @import("std");
+const testing = std.testing;
+
+const gdzig = @import("gdzig");
+const allocator = gdzig.testing.allocator;
+const Node = gdzig.class.Node;
+const Object = gdzig.class.Object;
+const Variant = gdzig.builtin.Variant;

--- a/test/nullable_object_method/root.zig
+++ b/test/nullable_object_method/root.zig
@@ -1,7 +1,10 @@
 pub fn register(r: *gdzig.extension.Registry) void {
+    r.addClass(NullableResource, {}, .auto);
     const class = r.createClass(NullableObjectNode, {}, .auto);
     class.addMethod("accept_node", .auto);
     class.addMethod("null_node", .auto);
+    class.addMethod("accept_resource", .auto);
+    class.addMethod("echo_resource", .auto);
 }
 
 fn ensureRegistered() void {
@@ -38,6 +41,86 @@ test "bound methods accept and return nullable object pointers" {
     try testing.expect(nullable.? == null);
 }
 
+test "ptrcall accepts and returns nullable extension RefCounted pointers" {
+    ensureRegistered();
+
+    const receiver = try NullableObjectNode.create();
+    defer receiver.base.destroy();
+    const resource = try NullableResource.create();
+    defer resource.base.destroy();
+
+    const accept_config = gdzig.extension.testing.MethodConfig(NullableObjectNode).fromName(
+        "accept_resource",
+        "acceptResource",
+        .{},
+    );
+
+    var resource_ref: ?*anyopaque = null;
+    gdzig.raw.refSetObject(@ptrCast(&resource_ref), @ptrCast(resource.base));
+    defer gdzig.raw.refSetObject(@ptrCast(&resource_ref), null);
+
+    const resource_args = [_]?*const anyopaque{@ptrCast(&resource_ref)};
+    var accepted: u8 = 0;
+    accept_config.ptr_call.?(receiver, @ptrCast(&resource_args), @ptrCast(&accepted));
+    try testing.expectEqual(@as(u8, 1), accepted);
+
+    var null_ref: ?*anyopaque = null;
+    const null_args = [_]?*const anyopaque{@ptrCast(&null_ref)};
+    accepted = 1;
+    accept_config.ptr_call.?(receiver, @ptrCast(&null_args), @ptrCast(&accepted));
+    try testing.expectEqual(@as(u8, 0), accepted);
+
+    const echo_config = gdzig.extension.testing.MethodConfig(NullableObjectNode).fromName(
+        "echo_resource",
+        "echoResource",
+        .{},
+    );
+
+    var returned_ref: ?*anyopaque = null;
+    echo_config.ptr_call.?(receiver, @ptrCast(&resource_args), @ptrCast(&returned_ref));
+    defer gdzig.raw.refSetObject(@ptrCast(&returned_ref), null);
+    try testing.expectEqual(@as(?*anyopaque, @ptrCast(resource.base)), gdzig.raw.refGetObject(@ptrCast(&returned_ref)));
+
+    gdzig.raw.refSetObject(@ptrCast(&returned_ref), null);
+    echo_config.ptr_call.?(receiver, @ptrCast(&null_args), @ptrCast(&returned_ref));
+    try testing.expect(gdzig.raw.refGetObject(@ptrCast(&returned_ref)) == null);
+}
+
+test "ptrcall accepts and returns nullable non-RefCounted object pointers" {
+    ensureRegistered();
+
+    const receiver = try NullableObjectNode.create();
+    defer receiver.base.destroy();
+    const node = Node.init();
+    defer node.destroy();
+
+    const accept_config = gdzig.extension.testing.MethodConfig(NullableObjectNode).fromName(
+        "accept_node",
+        "acceptNode",
+        .{},
+    );
+
+    const node_args = [_]?*const anyopaque{@ptrCast(node)};
+    var accepted: u8 = 0;
+    accept_config.ptr_call.?(receiver, @ptrCast(&node_args), @ptrCast(&accepted));
+    try testing.expectEqual(@as(u8, 1), accepted);
+
+    const null_args = [_]?*const anyopaque{null};
+    accepted = 1;
+    accept_config.ptr_call.?(receiver, @ptrCast(&null_args), @ptrCast(&accepted));
+    try testing.expectEqual(@as(u8, 0), accepted);
+
+    const null_config = gdzig.extension.testing.MethodConfig(NullableObjectNode).fromName(
+        "null_node",
+        "nullNode",
+        .{},
+    );
+
+    var returned_ptr: ?*Node = node;
+    null_config.ptr_call.?(receiver, @ptrCast(&[_]?*const anyopaque{}), @ptrCast(&returned_ptr));
+    try testing.expect(returned_ptr == null);
+}
+
 const NullableObjectNode = struct {
     base: *Node,
 
@@ -61,6 +144,31 @@ const NullableObjectNode = struct {
         _ = self;
         return null;
     }
+
+    pub fn acceptResource(self: *NullableObjectNode, resource: ?*NullableResource) bool {
+        _ = self;
+        return resource != null;
+    }
+
+    pub fn echoResource(self: *NullableObjectNode, resource: ?*NullableResource) ?*NullableResource {
+        _ = self;
+        return resource;
+    }
+};
+
+const NullableResource = struct {
+    base: *Resource,
+
+    pub fn create() !*NullableResource {
+        const self = try allocator.create(NullableResource);
+        self.* = .{ .base = .init() };
+        self.base.setInstance(NullableResource, self);
+        return self;
+    }
+
+    pub fn destroy(self: *NullableResource) void {
+        allocator.destroy(self);
+    }
 };
 
 const std = @import("std");
@@ -70,4 +178,5 @@ const gdzig = @import("gdzig");
 const allocator = gdzig.testing.allocator;
 const Node = gdzig.class.Node;
 const Object = gdzig.class.Object;
+const Resource = gdzig.class.Resource;
 const Variant = gdzig.builtin.Variant;


### PR DESCRIPTION
## Summary

Found while chasing a leak in a GDExtension built on gdzig. Four fixes, ptrcall/varcall ownership is the headline.

- **Release the varcall return value.** A bound method has two entry points, ptrcall and varcall, and they disagreed on return ownership. `writePtrReturn` moves the value into the engine's return slot, so the caller adopts it. Varcall copied it into a `Variant` via the copy constructor and never released the callee's local. Result: no return convention was correct on both paths — a method returning a fresh `Array` leaked on varcall, a method returning a borrowed one was only safe on varcall. Fix standardizes on ptrcall's convention (builtin returns are moved/adopted by the caller) and releases the callee's local after boxing on varcall. Dispatch is `@hasDecl(ReturnType, "deinit")` on structs, which is the type-driven form of `has_destructor` in extension_api (checked against all 21 builtins, matches on all 17 that have one). Object-pointer returns are untouched — `writePtrReturn`/`refSetObject` and `Variant.init` already agree, both take a ref for the caller.
- **Nullable object support.** `variant.zig` and `class.mixin.zig` didn't handle null object args/returns. New suite `test/nullable_object_method`, 3 tests.
- **Marshal nullable ref ptrcalls.** Follow-up to the above for the ptrcall path specifically.
- **Declare linux arm64 in the test gdextension.** The generated test project only listed x86_64, so on an arm64 host Godot loaded no library, every Godot-backed suite died with NoResponse, and the build still exited 0. Now the harness actually runs on arm64.

### Breaking change

If a method returned a *borrowed* builtin (a handle the callee kept and reused elsewhere), that was previously only correct on varcall. It's now a double-free there too. Return a fresh copy instead.

### Relation to existing tests

22e8868 already pins the object half of this convention (borrowed `*Resource` via varcall, refcount 1→2→1). This PR does the builtin half — both tests pass together. Same fix family as #220 (ptrcall widths / pending refs) and #215 (ptrcall `Ref<T>` refcount leak).

One case is deliberately left alone: `Variant` itself has a `deinit` and would match the release predicate, but it's unreachable as a return type today since `Tag.forType` has no `Variant` case and compile-errors first. Commented in `method.zig` in case a pass-through `Variant` return ever gets added — it would need to be exempted or have its ownership re-derived.

## Test plan

- [x] Full suite on linux arm64: 136/136 steps, 75/75 tests
- [x] `test-leaks`: 4/4, including new case "varcall adopts a builtin return value"
